### PR TITLE
lg-hammerhead: init

### DIFF
--- a/devices/lg-hammerhead/all-modules.nix
+++ b/devices/lg-hammerhead/all-modules.nix
@@ -1,0 +1,220 @@
+[
+
+  # bmp280@76 compatible="bosch,bmp280"
+  "bmp280_spi"
+
+  # bq24192@6b compatible="ti,bq24192"
+  "bq24190_charger"
+
+  # bt compatible="qcom,wcnss-bt"
+  "btqcomsmd"
+
+  # clock-controller compatible="qcom,rpmcc-msm8974"
+  "clk_smd_rpm"
+
+  # vibrator compatible="clk-vibrator"
+  "clk_vibrator"
+
+  # misc@900 compatible="qcom,pm8941-misc"
+  "extcon_qcom_spmi_misc"
+
+  # bluetooth compatible="brcm,bcm43438-bt"
+  "hci_uart"
+
+  # i2c@f9923000 compatible="qcom,i2c-qup-v2.1.1"
+  # i2c@f9924000 compatible="qcom,i2c-qup-v2.1.1"
+  # i2c@f9925000 compatible="qcom,i2c-qup-v2.1.1"
+  # i2c@f9928000 compatible="qcom,i2c-qup-v2.1.1"
+  # i2c@f9964000 compatible="qcom,i2c-qup-v2.1.1"
+  # i2c@f9967000 compatible="qcom,i2c-qup-v2.1.1"
+  # i2c@f9968000 compatible="qcom,i2c-qup-v2.1.1"
+  "i2c_qup"
+
+  # mpu6515@68 compatible="invensense,mpu6515"
+  "inv_mpu6050_i2c"
+
+  # led-controller@38 compatible="ti,lm3630a"
+  "lm3630a_bl"
+
+  # mdss@fd900000 compatible="qcom,mdss"
+  # mdp@fd900000 compatible="qcom,mdp5"
+  "msm"
+
+  # qfprom@fc4bc000 compatible="qcom,qfprom"
+  "nvmem_qfprom"
+
+  # ocmem@fdd00000 compatible="qcom,msm8974-ocmem"
+  "ocmem"
+
+  # phy@a compatible="qcom,usb-hs-phy"
+  # phy@b compatible="qcom,usb-hs-phy"
+  "phy_qcom_usb_hs"
+
+  # pwrkey@800 compatible="qcom,pm8941-pwrkey"
+  "pm8941_pwrkey"
+
+  # coincell@2800 compatible="qcom,pm8941-coincell"
+  "qcom_coincell"
+
+  # tcsr-mutex compatible="qcom,tcsr-mutex"
+  "qcom_hwspinlock"
+
+  # remoteproc@fc880000 compatible="qcom,msm8974-mss-pil"
+  "qcom_q6v5_mss"
+
+  # adsp-pil compatible="qcom,msm8974-adsp-pil"
+  "qcom_q6v5_pas"
+
+  # rng@f9bff000 compatible="qcom,prng"
+  "qcom_rng"
+
+  # charger@1000 compatible="qcom,pm8941-charger"
+  "qcom_smbb"
+
+  # smd compatible="qcom,smd"
+  "qcom_smd"
+
+  # pm8841-regulators compatible="qcom,rpm-pm8841-regulators"
+  # pm8941-regulators compatible="qcom,rpm-pm8941-regulators"
+  # pma8084-regulators compatible="qcom,rpm-pma8084-regulators"
+  "qcom_smd_regulator"
+
+  # iadc@3600 compatible="qcom,spmi-iadc"
+  "qcom_spmi_iadc"
+
+  # regulators compatible="qcom,pm8941-regulators"
+  "qcom_spmi_regulator"
+
+  # temp-alarm@2400 compatible="qcom,spmi-temp-alarm"
+  # temp-alarm@2400 compatible="qcom,spmi-temp-alarm"
+  "qcom_spmi_temp_alarm"
+
+  # vadc@3100 compatible="qcom,spmi-vadc"
+  "qcom_spmi_vadc"
+
+  # thermal-sensor@fc4a9000 compatible="qcom,msm8974-tsens"
+  "qcom_tsens"
+
+  # remoteproc@fb21b000 compatible="qcom,pronto-v2-pil"
+  # iris compatible="qcom,wcn3680"
+  "qcom_wcnss_pil"
+
+  # wled@d800 compatible="qcom,pm8941-wled"
+  "qcom_wled"
+
+  # interconnect@fc380000 compatible="qcom,msm8974-bimc"
+  # interconnect@fc460000 compatible="qcom,msm8974-snoc"
+  # interconnect@fc468000 compatible="qcom,msm8974-pnoc"
+  # interconnect@fc470000 compatible="qcom,msm8974-ocmemnoc"
+  # interconnect@fc478000 compatible="qcom,msm8974-mmssnoc"
+  # interconnect@fc480000 compatible="qcom,msm8974-cnoc"
+  "qnoc_msm8974"
+
+  # synaptics@70 compatible="syna,rmi4-i2c"
+  "rmi_i2c"
+
+  # rmtfs@fd80000 compatible="qcom,rmtfs-mem"
+  "rmtfs_mem"
+
+  # rtc@6000 compatible="qcom,pm8941-rtc"
+  "rtc_pm8xxx"
+
+  # rpm_requests compatible="qcom,rpm-msm8974"
+  "smd_rpm"
+
+  # smem compatible="qcom,smem"
+  "smem"
+
+  # smp2p-adsp compatible="qcom,smp2p"
+  # smp2p-modem compatible="qcom,smp2p"
+  # smp2p-wcnss compatible="qcom,smp2p"
+  "smp2p"
+
+  # smsm compatible="qcom,smsm"
+  "smsm"
+
+  # reboot-mode compatible="syscon-reboot-mode"
+  "syscon_reboot_mode"
+
+  # avago_apds993@39 compatible="avago,apds9930"
+  "tsl2772"
+
+  # wifi compatible="qcom,wcnss-wlan"
+  "wcn36xx"
+
+  # wcnss compatible="qcom,wcnss"
+  "wcnss_ctrl"
+
+  # unmatched #device(name='', compatible=['lge,hammerhead', 'qcom,msm8974'])
+  # unmatched #device(name='cpu@0', compatible=['qcom,krait'])
+  # unmatched #device(name='cpu@1', compatible=['qcom,krait'])
+  # unmatched #device(name='cpu@2', compatible=['qcom,krait'])
+  # unmatched #device(name='cpu@3', compatible=['qcom,krait'])
+  # unmatched #device(name='l2-cache', compatible=['cache'])
+  # unmatched #device(name='spc', compatible=['qcom,idle-state-spc', 'arm,idle-state'])
+  # unmatched #device(name='cpu-pmu', compatible=['qcom,krait-pmu'])
+  # unmatched #device(name='xo_board', compatible=['fixed-clock'])
+  # unmatched #device(name='sleep_clk', compatible=['fixed-clock'])
+  # unmatched #device(name='timer', compatible=['arm,armv7-timer'])
+  # unmatched #device(name='scm', compatible=['qcom,scm'])
+  # unmatched #device(name='soc', compatible=['simple-bus'])
+  # unmatched #device(name='interrupt-controller@f9000000', compatible=['qcom,msm-qgic2'])
+  # unmatched #device(name='syscon@f9011000', compatible=['syscon'])
+  # unmatched #device(name='timer@f9020000', compatible=['arm,armv7-timer-mem'])
+  # unmatched #device(name='power-controller@f9089000', compatible=['qcom,msm8974-saw2-v2.1-cpu', 'qcom,saw2'])
+  # unmatched #device(name='power-controller@f9099000', compatible=['qcom,msm8974-saw2-v2.1-cpu', 'qcom,saw2'])
+  # unmatched #device(name='power-controller@f90a9000', compatible=['qcom,msm8974-saw2-v2.1-cpu', 'qcom,saw2'])
+  # unmatched #device(name='power-controller@f90b9000', compatible=['qcom,msm8974-saw2-v2.1-cpu', 'qcom,saw2'])
+  # unmatched #device(name='power-controller@f9012000', compatible=['qcom,saw2'])
+  # unmatched #device(name='clock-controller@f9088000', compatible=['qcom,kpss-acc-v2'])
+  # unmatched #device(name='clock-controller@f9098000', compatible=['qcom,kpss-acc-v2'])
+  # unmatched #device(name='clock-controller@f90a8000', compatible=['qcom,kpss-acc-v2'])
+  # unmatched #device(name='clock-controller@f90b8000', compatible=['qcom,kpss-acc-v2'])
+  # unmatched #device(name='restart@fc4ab000', compatible=['qcom,pshold'])
+  # unmatched #device(name='clock-controller@fc400000', compatible=['qcom,gcc-msm8974'])
+  # unmatched #device(name='syscon@fd4a0000', compatible=['syscon'])
+  # unmatched #device(name='syscon@fd484000', compatible=['syscon'])
+  # unmatched #device(name='clock-controller@fd8c0000', compatible=['qcom,mmcc-msm8974'])
+  # unmatched #device(name='memory@fc428000', compatible=['qcom,rpm-msg-ram'])
+  # unmatched #device(name='serial@f991d000', compatible=['qcom,msm-uartdm-v1.4', 'qcom,msm-uartdm'])
+  # unmatched #device(name='serial@f991e000', compatible=['qcom,msm-uartdm-v1.4', 'qcom,msm-uartdm'])
+  # unmatched #device(name='serial@f995d000', compatible=['qcom,msm-uartdm-v1.4', 'qcom,msm-uartdm'])
+  # unmatched #device(name='serial@f9960000', compatible=['qcom,msm-uartdm-v1.4', 'qcom,msm-uartdm'])
+  # unmatched #device(name='sdhci@f9824900', compatible=['qcom,msm8974-sdhci', 'qcom,sdhci-msm-v4'])
+  # unmatched #device(name='sdhci@f9864900', compatible=['qcom,msm8974-sdhci', 'qcom,sdhci-msm-v4'])
+  # unmatched #device(name='sdhci@f98a4900', compatible=['qcom,msm8974-sdhci', 'qcom,sdhci-msm-v4'])
+  # unmatched #device(name='bcrmf@1', compatible=['brcm,bcm4339-fmac', 'brcm,bcm4329-fmac'])
+  # unmatched #device(name='usb@f9a55000', compatible=['qcom,ci-hdrc'])
+  # unmatched #device(name='pinctrl@fd510000', compatible=['qcom,msm8974-pinctrl'])
+  # unmatched #device(name='ak8963@f', compatible=['asahi-kasei,ak8963'])
+  # unmatched #device(name='spmi@fc4cf000', compatible=['qcom,spmi-pmic-arb'])
+  # unmatched #device(name='pm8841@4', compatible=['qcom,pm8841', 'qcom,spmi-pmic'])
+  # unmatched #device(name='mpps@a000', compatible=['qcom,pm8841-mpp', 'qcom,spmi-mpp'])
+  # unmatched #device(name='pm8841@5', compatible=['qcom,pm8841', 'qcom,spmi-pmic'])
+  # unmatched #device(name='pm8941@0', compatible=['qcom,pm8941', 'qcom,spmi-pmic'])
+  # unmatched #device(name='gpios@c000', compatible=['qcom,pm8941-gpio', 'qcom,spmi-gpio'])
+  # unmatched #device(name='mpps@a000', compatible=['qcom,pm8941-mpp', 'qcom,spmi-mpp'])
+  # unmatched #device(name='pm8941@1', compatible=['qcom,pm8941', 'qcom,spmi-pmic'])
+  # unmatched #device(name='dma-controller@f9944000', compatible=['qcom,bam-v1.4.0'])
+  # unmatched #device(name='etr@fc322000', compatible=['arm,coresight-tmc', 'arm,primecell'])
+  # unmatched #device(name='tpiu@fc318000', compatible=['arm,coresight-tpiu', 'arm,primecell'])
+  # unmatched #device(name='replicator@fc31c000', compatible=['arm,coresight-dynamic-replicator', 'arm,primecell'])
+  # unmatched #device(name='etf@fc307000', compatible=['arm,coresight-tmc', 'arm,primecell'])
+  # unmatched #device(name='funnel@fc31b000', compatible=['arm,coresight-dynamic-funnel', 'arm,primecell'])
+  # unmatched #device(name='funnel@fc31a000', compatible=['arm,coresight-dynamic-funnel', 'arm,primecell'])
+  # unmatched #device(name='funnel@fc345000', compatible=['arm,coresight-dynamic-funnel', 'arm,primecell'])
+  # unmatched #device(name='etm@fc33c000', compatible=['arm,coresight-etm4x', 'arm,primecell'])
+  # unmatched #device(name='etm@fc33d000', compatible=['arm,coresight-etm4x', 'arm,primecell'])
+  # unmatched #device(name='etm@fc33e000', compatible=['arm,coresight-etm4x', 'arm,primecell'])
+  # unmatched #device(name='etm@fc33f000', compatible=['arm,coresight-etm4x', 'arm,primecell'])
+  # unmatched #device(name='opp_table', compatible=['operating-points-v2'])
+  # unmatched #device(name='adreno@fdb00000', compatible=['qcom,adreno-330.2', 'qcom,adreno'])
+  # unmatched #device(name='dsi@fd922800', compatible=['qcom,mdss-dsi-ctrl'])
+  # unmatched #device(name='panel@0', compatible=['lg,acx467akm-7'])
+  # unmatched #device(name='dsi-phy@fd922a00', compatible=['qcom,dsi-phy-28nm-hpm'])
+  # unmatched #device(name='imem@fe805000', compatible=['syscon', 'simple-mfd'])
+  # unmatched #device(name='gpio-keys', compatible=['gpio-keys'])
+  # unmatched #device(name='vreg-boost', compatible=['regulator-fixed'])
+  # unmatched #device(name='vreg-vph-pwr', compatible=['regulator-fixed'])
+  # unmatched #device(name='wlan-regulator', compatible=['regulator-fixed'])
+]

--- a/devices/lg-hammerhead/default.nix
+++ b/devices/lg-hammerhead/default.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+
+let
+  kernel = pkgs.callPackage ./kernel {
+    kernelPatches = with pkgs; [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.request_key_helper
+      kernelPatches.export_kernel_fpu_functions."5.3"
+    ];
+    extraConfig = ''
+      HWSPINLOCK y
+      INTERCONNECT m
+      INTERCONNECT_QCOM y
+    '';
+  };
+
+  # The kernel should be generic and apply to any msm8974 device. To
+  # use it with a particular device we need to add the particular dtb
+  # to the kernel.
+  kernelWithDTB = dtbName: pkgs.runCommand "kernel-with-dtb" {
+    passthru = kernel.passthru // { file = "zImage-dtb"; unwrapped = kernel; };
+  } ''
+    mkdir $out
+    ln -s --target-directory=$out ${kernel}/*
+    cat ${kernel}/zImage ${kernel}/dtbs/${dtbName}.dtb > $out/zImage-dtb
+  '';
+in
+{
+  mobile.boot.stage-1.kernel = {
+    modular = true;
+    modules = import ./all-modules.nix;
+  };
+
+  mobile.device.name = "lg-hammerhead";
+
+  # Mostly adapted from postmarketOS
+  # https://gitlab.com/postmarketOS/pmaports/-/blob/a7553d6f3c8dcef0af5bda2ca3c71932c7d1dff0/device/testing/device-lg-hammerhead/deviceinfo
+  mobile.device.info = rec {
+    name = "LG Nexus 5";
+    format_version = "0";
+    manufacturer = "LG";
+    codename = "lg-hammerhead";
+    date = "";
+    # TODO : make kernel part of options.
+    kernel = kernelWithDTB dtb;
+    dtb = "qcom-msm8974-lge-nexus5-hammerhead";
+    modules_initfs = "pm8941_pwrkey qnoc_msm8974 rmi_i2c";
+    arch = "armv7l";
+    keyboard = "false";
+    external_storage = "false";
+    screen_width = "1080";
+    screen_height = "1920";
+    dev_touchscreen = "";
+    dev_touchscreen_calibration = "";
+    dev_keyboard = "";
+    flash_method = "fastboot";
+
+    kernel_cmdline = lib.concatStringsSep " " [
+      "cma=256M" # matches postmarketOS kernel config, necessary for display
+    ];
+
+    generate_bootimg = "true";
+    # bootimg_qcdt = false;
+    flash_offset_base = "0x00000000";
+    flash_offset_kernel = "0x00008000";
+    flash_offset_ramdisk = "0x2900000";
+    flash_offset_second = "0x00f00000";
+    flash_offset_tags = "0x02700000";
+    flash_pagesize = "2048";
+
+    gadgetfs.functions = {
+      rndis = "rndis.rndis";
+    };
+  };
+
+  mobile.hardware = {
+    soc = "qualcomm-msm8974";
+    ram = 1024 * 2;
+    screen = {
+      width = 1080; height = 1920;
+    };
+  };
+
+  mobile.system.type = "android";
+
+  mobile.usb.mode = "gadgetfs";
+  # Google
+  mobile.usb.idVendor = "18D1";
+  # "Nexus 4 (bootloader)" as reported by fastboot
+  mobile.usb.idProduct = "4ee0";
+}

--- a/devices/lg-hammerhead/kernel/default.nix
+++ b/devices/lg-hammerhead/kernel/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchFromGitLab, buildPackages, fetchurl, perl, buildLinux, ... } @ args:
+
+with stdenv.lib;
+
+buildLinux (args // rec {
+  version = "5.6.0-rc6";
+  modDirVersion = version;
+
+  # branchVersion needs to be x.y
+  extraMeta.branch = versions.majorMinor version;
+
+  src = fetchFromGitLab {
+    owner = "postmarketOS";
+    repo = "linux-postmarketos";
+    rev = "b9f39bdf61e5c8f5db63afe7ab1c9ff77aa6b4bc";
+    sha256 = "105v5gzqc4avdwzm6y2mz52c08dnv8m4fj7n4l0vdqrz7y1rdabs";
+  };
+} // (args.argsOverride or {}))

--- a/devices/lg-hammerhead/partitions
+++ b/devices/lg-hammerhead/partitions
@@ -1,0 +1,39 @@
+Disk /dev/mmcblk1: 30777344 sectors, 14.7 GiB
+Sector size (logical/physical): 512/512 bytes
+Disk identifier (GUID): 98101B32-BBE2-4BF2-A06E-2BB33D000C20
+Partition table holds up to 32 entries
+Main partition table begins at sector 2 and ends at sector 9
+First usable sector is 34, last usable sector is 30777310
+Partitions will be aligned on 4-sector boundaries
+Total free space is 990 sectors (495.0 KiB)
+
+Number  Start (sector)    End (sector)  Size       Code  Name
+   1            1024          132095   64.0 MiB    0700  modem
+   2          132096          134143   1024.0 KiB  A012  sbl1
+   3          134144          135167   512.0 KiB   A018  rpm
+   4          135168          136191   512.0 KiB   A016  tz
+   5          136192          137215   512.0 KiB   A019  sdi
+   6          137216          138239   512.0 KiB   A015  aboot
+   7          138240          142335   2.0 MiB     0700  pad
+   8          142336          144383   1024.0 KiB  FFFF  sbl1b
+   9          144384          145407   512.0 KiB   FFFF  tzb
+  10          145408          146431   512.0 KiB   FFFF  rpmb
+  11          146432          147455   512.0 KiB   FFFF  abootb
+  12          147456          153599   3.0 MiB     A027  modemst1
+  13          153600          159743   3.0 MiB     A028  modemst2
+  14          159744          160767   512.0 KiB   8301  metadata
+  15          160768          193535   16.0 MiB    FFFF  misc
+  16          193536          226303   16.0 MiB    8300  persist
+  17          226304          232447   3.0 MiB     FFFF  imgdata
+  18          232448          277503   22.0 MiB    A03B  laf
+  19          277504          322559   22.0 MiB    A036  boot
+  20          322560          367615   22.0 MiB    A036  recovery
+  21          367616          373759   3.0 MiB     A02A  fsg
+  22          373760          374783   512.0 KiB   A029  fsc
+  23          374784          375807   512.0 KiB   A02C  ssd
+  24          375808          376831   512.0 KiB   A01A  DDR
+  25          376832         2473983   1024.0 MiB  0700  system
+  26         2473984         2535423   30.0 MiB    FFFF  crypto
+  27         2535424         3969023   700.0 MiB   0700  cache
+  28         3969024        30777299   12.8 GiB    0700  userdata
+  29        30777300        30777310   5.5 KiB     0700  grow

--- a/modules/hardware-qualcomm.nix
+++ b/modules/hardware-qualcomm.nix
@@ -22,6 +22,11 @@ in
       default = false;
       description = "enable when SOC is msm8939";
     };
+    hardware.socs.qualcomm-msm8974.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "enable when SOC is msm8974";
+    };
     hardware.socs.qualcomm-msm8996.enable = mkOption {
       type = types.bool;
       default = false;
@@ -50,6 +55,11 @@ in
       mobile = mkIf cfg.qualcomm-msm8953.enable {
         system.system = "aarch64-linux";
         quirks.qualcomm.msm-fb-refresher.enable = true;
+      };
+    }
+    {
+      mobile = mkIf cfg.qualcomm-msm8974.enable {
+        system.system = "armv7l-linux";
       };
     }
     {


### PR DESCRIPTION
This is a minimal configuration that allows booting and should serve as a starting point for anyone looking to work on this device. There are a few problems that still need resolving, but I don't believe that anything here is incorrect.

The display sometimes freezes with `msm fd900000.mdss: pp done time out, lm=0`. There was a [proposed patch](https://lkml.org/lkml/2019/11/12/288) but applying it only seemed to help a little. See also [postmarketOS/pmaports#51](https://gitlab.com/postmarketOS/pmaports/-/issues/51).

I did not add any peripheral firmwares.