### PR TITLE
initrd: use pkgs.kmod for modprobe instead of busybox

### DIFF
--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -170,6 +170,10 @@ let
         inherit (pkgs) udev;
       in
         ''
+          # Copy modprobe.
+          copy_bin_and_libs ${pkgs.kmod}/bin/kmod
+          ln -sf kmod $out/bin/modprobe
+
           # Copy udev.
           copy_bin_and_libs ${udev}/lib/systemd/systemd-udevd
           copy_bin_and_libs ${udev}/bin/udevadm


### PR DESCRIPTION
Removes "Unknown symbol" errors while booting:

```
[    3.817788] bmp280_spi: Unknown symbol bmp280_regmap_config (err -2)
[    3.817844] bmp280_spi: Unknown symbol bmp280_common_probe (err -2)
[    3.823219] bmp280_spi: Unknown symbol bmp280_dev_pm_ops (err -2)
[    3.829247] bmp280_spi: Unknown symbol bmp180_regmap_config (err -2)
```

---

This might come down to personal taste a little. I was having trouble getting the right modules loaded for usb rndis while working on the lg hammerhead. The actual resolution to that was #141, but I tried this as well after seeing the "Unknown symbol" errors printed. It does makes the boot log shorter and cleaner.