### PR TITLE
pine64-pinephone-braveheart: implementation of Crust

### DIFF
--- a/devices/pine64-pinephone/overlay/crust-firmware/default.nix
+++ b/devices/pine64-pinephone/overlay/crust-firmware/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub
+, flex, yacc, or1k-toolchain }:
+
+stdenv.mkDerivation rec {
+  pname = "crust-firmware";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "crust-firmware";
+    repo = "crust";
+    rev = "v${version}";
+    sha256 = "1ncn2ncmkj1cjk68zrgr5yk7b9x1xxcrcmk9jf188svjgk0cq2m5";
+  };
+
+  depsBuildBuild = [
+    stdenv.cc
+  ];
+
+  nativeBuildInputs = [
+    flex
+    yacc
+  ] ++ (with or1k-toolchain; [
+    binutils
+    gcc
+  ]);
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "= lex" '= ${flex}/bin/flex'
+  '';
+
+  buildPhase = ''
+    export CROSS_COMPILE=or1k-elf-
+    export HOST_COMPILE=${stdenv.cc}/bin/${stdenv.cc.bintools.targetPrefix}
+
+    make pinephone_defconfig
+    make scp
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v build/scp/scp.bin $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Libre SCP firmware for Allwinner sunxi SoCs";
+    homepage = "https://github.com/crust-firmware/crust";
+    license = with licenses; [ bsd3 gpl2Only mit ];
+    maintainers = [ maintainers.noneucat ];
+    platforms = platforms.all;
+  };
+}
+

--- a/devices/pine64-pinephone/overlay/default.nix
+++ b/devices/pine64-pinephone/overlay/default.nix
@@ -2,4 +2,14 @@ final: super: {
   pine64-pinephone = {
     qfirehose = final.callPackage ./qfirehose {};
   };
+
+  crustFirmware = final.callPackage ./crust-firmware {
+    inherit (final.buildPackages)
+      stdenv
+      flex
+      yacc
+    ;
+
+    or1k-toolchain = final.pkgsCross.or1k.buildPackages;
+  };
 }

--- a/devices/pine64-pinephone/u-boot/default.nix
+++ b/devices/pine64-pinephone/u-boot/default.nix
@@ -3,8 +3,10 @@
 , callPackage
 , buildUBoot
 , armTrustedFirmwareAllwinner
+, crustFirmware
 , fetchpatch
 , fetchurl
+, fetchFromGitHub
 }:
 
 let
@@ -13,11 +15,24 @@ let
     name = "${id}.patch";
     url = "https://patchwork.ozlabs.org/patch/${id}/raw/";
   };
+
+  # use a version of ATF that has all the Crust goodies in it
+  crustATF = armTrustedFirmwareAllwinner.overrideAttrs(old: rec {
+    name = "arm-trusted-firmware-crust-${version}";
+    version = "2.4";
+    src = fetchFromGitHub {
+      owner = "crust-firmware";
+      repo = "arm-trusted-firmware";
+      rev = "42b9ab0cbe6c1d687fe331c547d28489e12260c3";
+      sha256 = "13q0946qk2brda1ci3bsri359ly8zhz76f2d1svnlh45rrrfn984";
+    };
+  });
 in
 (buildUBoot {
   defconfig = "pinephone_defconfig";
   extraMeta.platforms = ["aarch64-linux"];
-  BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+  BL31 = "${crustATF}/bl31.bin";
+  SCP = "${crustFirmware}/scp.bin";
 
   extraPatches = [
     # https://patchwork.ozlabs.org/patch/1202024


### PR DESCRIPTION
Closes #183.

~~A blob of the Crust firmware has been provided for testing purposes; the final PR will build the firmware from source.~~

**Blockers:**
- ~~kernel update to 5.7~~
- ~~u-boot update to https://gitlab.com/pine64-org/u-boot/-/tree/crust (makes sense to couple with the kernel update PR)~~
- ~~update patches for versioned DTBs (ditto)~~
- or1k support in nixpkgs so we can compile Crust ourselves (https://github.com/NixOS/nixpkgs/pull/93368)

**Issues:**
- ~~pinephone seems to immediately resume after suspend-to-RAM (not sure why?)~~
- ~~screen does not work~~