### PR TITLE
boot/lib/lvgui: fix libxkbcommon after nixpkgs#108004

### DIFF
--- a/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
@@ -54,22 +54,23 @@ let
     ];
   });
   libxkbcommon = pkgs.callPackage (
-    { stdenv                                             
-    , libxkbcommon                             
-    , meson             
-    , ninja                                         
-    , pkgconfig               
-    , yacc                              
-    }:                            
+    { stdenv
+    , libxkbcommon
+    , meson
+    , ninja
+    , pkgconfig
+    , yacc
+    }:
 
     libxkbcommon.overrideAttrs({...}: {
       nativeBuildInputs = [ meson ninja pkgconfig yacc ];
-      buildInputs = [ ];                                     
+      buildInputs = [ ];
 
-      mesonFlags = [   
+      mesonFlags = [
         "-Denable-wayland=false"
-        "-Denable-x11=false"             
-        "-Denable-docs=false"            
+        "-Denable-x11=false"
+        "-Denable-docs=false"
+        "-Denable-xkbregistry=false"
 
         # This is because we're forcing uses of this build
         # to define config and locale root; for stage-1 use.


### PR DESCRIPTION
Adds new `libxml2` dependency to the `lvgui` build of `libxkbcommon`