### PR TITLE
add a .dev output to the kernel derivation, so we can use headers

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -165,6 +165,8 @@ stdenv.mkDerivation (inputArgs // {
   inherit qcdt_dtbs exynos_dtbs exynos_platform exynos_subtype;
   inherit enableParallelBuilding;
 
+  outputs = [ "out" "dev" ];
+
   # Allows disabling the kernel config normalization.
   # Set to false when normalizing the kernel config.
   forceNormalizedConfig = true;
@@ -368,6 +370,10 @@ stdenv.mkDerivation (inputArgs // {
     echo ":: Running postBuild hook before postInstall (combined build/install quirk)"
     runHook postBuild
 
+  '' + ''
+    echo ":: Installing header files"
+    echo make $makeFlags "''${makeFlagsArray[@]}"  INSTALL_HDR_PATH=$out/ headers_install
+    make $makeFlags "''${makeFlagsArray[@]}"  INSTALL_HDR_PATH=$out/ headers_install
   '' + ''
     echo ":: Copying configuration file"
     # Helpful in cases where the kernel isn't built with /proc/config.gz


### PR DESCRIPTION
In order to build the poetically named "libqipcrtr4msmipc" project (relevant to modem support on Qualcomm) I need headers files from the vendor kernel that don't exist in mainline. What do you think about making the kernel builder into a multi-output derivation?

How I use it:
```
  let libqipcrtr4msmipc = kernel:
    let pname = "libqipcrtr4msmipc";
    in pkgs.stdenv.mkDerivation {
      inherit pname;
      buildInputs = [ kernel ];
      version = "0.1";
      preConfigure = ''
        makeFlags="prefix=$out CFLAGS=-I${kernel}/include"
      '';
      src = pkgs.fetchFromGitHub {
        repo = pname;
        owner = "telent";
        rev = "061c63c246ff6a29de899621a095696b08b3d1a3";
        sha256 = "197kd1bjhcaq1lh91abng8fx00a7fsnx5hs6prr0fdnwwmdriqh4";
      };
      installPhase = ''
        mkdir -p $out/lib
        cp ${pname}.so $out/lib
      '';
  };
  
 # [ ..... ]
in {
      environment.systemPackages = [(libqipcrtr4msmipc config.mobile.boot.stage-1.kernel.package.dev)]
 }

```

I'm by no means wedded to this solution, so feel free to suggest alternatives