### PR TITLE
Added flake support and helper

### DIFF
--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -151,7 +151,6 @@ which simplifies the process and sets up proper cross compilation.
           users.users.root.password = "111111";
         })
       ];
-      outputs = [ "disk-image" ];
     };
 }
 ```
@@ -159,12 +158,9 @@ which simplifies the process and sets up proper cross compilation.
 The helper creates a `nixosConfigurations` attribute with `hostname` so you
 can update the system with `nixos-rebuild` but it also sets up some `packages`
 attributes so you can create a flashable-zip for example for the first-time
-install with `nix build .#<hostname>_<output>`.
-
-`outputs` is used to define which derivations in `config.system.build.*` you
-want to build. This primarily depends on your target device. On `uefi-x86_64`
-you may want to build the `disk-image` output while on many android devices you
-might need `android-flashable-zip`.
+install with `nix build .#<hostname>_<output>`. It also sets the default
+package to the default output so a simple `nix build` will probably build
+your desired output. You can check all available outputs with `nix flake show`.
 
 === Manual setup with `nixpkgs.lib.nixosSystem`
 You may also manually setup the `nixosConfigurations` attribute for the flake
@@ -192,7 +188,7 @@ further complication in regards to cross compilation.
 }
 ```
 
-Now you can build this configuration using `nix build .#nixosConfigurations.mobile.config.system.build.android-flashable-zip`.
+Now you can build this configuration using `nix build .#nixosConfigurations.mobile.config.mobile.outputs.default`.
 However, it may lead to an error like:
 ```
 error: a 'aarch64-linux' with features {} is required to build ...

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -124,6 +124,45 @@ system configuration. It is recommended to copy and edit the configuration
 files from the `examples` directories if you are basing your configuration off
 of an example.
 
+== Configuration via flakes
+
+Mobile NixOS is flakes compatible, meaning you can configure it entirely using
+flakes.
+All devices are exported as `nixosModules` so you just need to import them to
+setup NixOS. You can also use the provided helper `mobileFlake` to simplify
+the process and setup proper cross compilation.
+
+```nix
+{
+  description = "nixos mobile distro";
+
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.mobile-nixos.url = "github:NixOS/mobile-nixos";
+
+  outputs = { self, nixpkgs, mobile-nixos }:
+    mobile-nixos.lib.mobileFlake {
+      hostname = "ark-test";
+      system = "x86_64-linux";
+      modules = [
+        mobile-nixos.nixosModules.uefi-x86_64
+        ({
+          users.users.root.password = "111111";
+        })
+      ];
+      outputs = [ "disk-image" ];
+    };
+}
+```
+
+The helper creates a `nixosConfigurations` attribute with `hostname` so you
+can update the system with `nixos-rebuild` but it also sets up some `packages`
+attributes so you can create a flashable-zip for example for the first-time
+install with `nix build .#<hostname>_<output>`.
+
+`outputs` is used to define which derivations in `config.system.build.*` you
+want to build. This primarily depends on your target device. On `uefi-x86_64`
+you may want to build the `disk-image` output while on any android device you
+might need `android-flashable-zip`.
 
 == Contributing
 

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -128,13 +128,15 @@ of an example.
 
 Mobile NixOS is flakes compatible, meaning you can configure it entirely using
 flakes.
-All devices are exported as `nixosModules` so you just need to import them to
-setup NixOS. You can also use the provided helper `mobileFlake` to simplify
-the process and setup proper cross compilation.
+
+=== Quickstart
+All devices are exported as `nixosModules` so you need to import them to setup
+Mobile NixOS. For a quickstart you should use the provided helper `mobileFlake`
+which simplifies the process and sets up proper cross compilation.
 
 ```nix
 {
-  description = "nixos mobile distro";
+  description = "Mobile NixOS configuration";
 
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
   inputs.mobile-nixos.url = "github:NixOS/mobile-nixos";
@@ -161,8 +163,48 @@ install with `nix build .#<hostname>_<output>`.
 
 `outputs` is used to define which derivations in `config.system.build.*` you
 want to build. This primarily depends on your target device. On `uefi-x86_64`
-you may want to build the `disk-image` output while on any android device you
+you may want to build the `disk-image` output while on many android devices you
 might need `android-flashable-zip`.
+
+=== Manual setup with `nixpkgs.lib.nixosSystem`
+You may also manually setup the `nixosConfigurations` attribute for the flake
+using the `nixpkgs.lib.nixosSystem` function. Note however that it may bring
+further complication in regards to cross compilation.
+
+```nix
+{
+  description = "Mobile NixOS configuration";
+
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.mobile-nixos.url = "github:NixOS/mobile-nixos";
+
+  outputs = { self, nixpkgs, mobile-nixos }:
+    nixosConfigurations.mobile = nixpkgs.lib.nixosSystem {
+      system = "aarch64-linux";
+      modules = [
+        mobile-nixos.nixosModules.xiaomi-begonia
+        ({
+          users.users.root.password = "111111";
+        })
+      ];
+    };
+  };
+}
+```
+
+Now you can build this configuration using `nix build .#nixosConfigurations.mobile.config.system.build.android-flashable-zip`.
+However, it may lead to an error like:
+```
+error: a 'aarch64-linux' with features {} is required to build ...
+```
+Which occurs due to missing cross compilation. You can only use an "emulated
+native build" when your host NixOS is configured with `boot.binfmt.emulatedSystems = [ "aarch64-linux" ];`.
+
+To properly cross-compile you need to set the system attribute to your host's
+system as the mobile-nixos modules correctly configure `nixpkgs.crossSystem`.
+However, this makes the flake configuration dependent on the build machine which
+is undesirable. For this reason the `mobileFlake` helper sets up this cross
+compilation for different build hosts using the `packages` attribute.
 
 == Contributing
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1629048390,
+        "narHash": "sha256-do7HuXFSKyj4ulMlRvGigNZCqOaGD9i0M3OLkFQgEAc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e41ba38114055832e5ba4a851e9c00149eef3e4a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1629048390,
@@ -17,6 +32,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Flakes for mobile-nixos";
+
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlay ]; });
+    in
+    {
+      overlay = import ./overlay/overlay.nix;
+
+      legacyPackages = forAllSystems (system: nixpkgsFor.${system});
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,13 @@
     };
 
     lib = {
+      /* Create a flake configuration with proper cross compilation setup.
+
+        @hostname: defines the hostname of the nixosConfiguration
+        @system: defines the system of the target device
+        @modules: selects which modules you want to import for the NixOS config
+        @outputs: selects which derivations under `config.system.build.*` you want to export as `packages`
+      */
       mobileFlake = { hostname, system, modules, outputs }:
         let
           mkMobile = buildSystem: nixpkgs.lib.nixosSystem {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,11 @@
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }: {
+  outputs = { self, nixpkgs, flake-utils }: let
+
+    buildSystems = [ "aarch64-linux" "x86_64-linux" ];
+
+  in {
     overlay = final: prev: (self.overlays.default final prev) // (self.overlays.mruby-builder final prev);
 
     overlays = {
@@ -35,7 +39,7 @@
         in
         {
           nixosConfigurations.${hostname} = mkMobile system;
-        } // flake-utils.lib.eachDefaultSystem (buildSystem: {
+        } // flake-utils.lib.eachSystem buildSystems (buildSystem: {
           packages = builtins.listToAttrs (builtins.map (mkOutput (mkMobile buildSystem)) outputs);
         });
     };
@@ -54,7 +58,7 @@
       in
       builtins.listToAttrs (builtins.map mkModule supportedDevices);
 
-  } // flake-utils.lib.eachDefaultSystem (system:
+  } // flake-utils.lib.eachSystem buildSystems (system:
     let
       pkgs = import nixpkgs {
         inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -58,14 +58,10 @@
       in
       builtins.listToAttrs (builtins.map mkModule supportedDevices);
 
-  } // flake-utils.lib.eachSystem buildSystems (system:
-    let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ self.overlay ];
-      };
-    in
-    {
-      legacyPackages = pkgs;
-    });
+  } // flake-utils.lib.eachSystem buildSystems (system: {
+    # shell.nix is already applying the overlay, so we do not need to import them ourself
+    devShell = import ./shell.nix { pkgs = import nixpkgs { inherit system; }; };
+
+    legacyPackages = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
+  });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,12 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlay ]; });
     in
     {
-      overlay = import ./overlay/overlay.nix;
+      overlay = final: prev: (self.overlays.default final prev) // (self.overlays.mruby-builder final prev);
+
+      overlays = {
+        default = import ./overlay/overlay.nix;
+        mruby-builder = import ./overlay/mruby-builder/overlay.nix;
+      };
 
       legacyPackages = forAllSystems (system: nixpkgsFor.${system});
     };

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,9 @@
   outputs = { self, nixpkgs }:
     let
       supportedSystems = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+      supportedDevices = builtins.filter
+        (device: builtins.pathExists(./. + "/devices/${device}/default.nix"))
+        (builtins.attrNames (builtins.readDir ./devices));
 
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
 
@@ -18,6 +21,14 @@
         default = import ./overlay/overlay.nix;
         mruby-builder = import ./overlay/mruby-builder/overlay.nix;
       };
+
+      nixosModules = builtins.listToAttrs (builtins.map
+        (device:
+          {
+            name = device;
+            value = (import ./lib/configuration.nix { inherit device; });
+          })
+        supportedDevices);
 
       legacyPackages = forAllSystems (system: nixpkgsFor.${system});
     };

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,9 +1,3 @@
-let
-  sha256 = "sha256-M5sHgjA1OZn/c21pk64qd5kjbkBpbZuYwgaDEl9kiP8=";
-  rev = "5bc8b980b9178ef9a4bb622320cf34e59ea2ea10";
-in
-builtins.trace "(Using pinned Nixpkgs at ${rev})"
-import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-  inherit sha256;
-})
+import (import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./.;
+}).defaultNix.inputs.nixpkgs


### PR DESCRIPTION
This pull request integrates Nix Flakes into this repository while maintaining backwards compatibility. I also added some documentation showing how users can utilise flakes.

Changes done:
- nix-shell is now defined inside the Nix Flake, providing a shell.nix as compatibility shim
- device configurations are exported as `nixosModules` allowing users to configure their mobile-nixos
- the overlays are now properly exported under `overlays` (and `legacyPackages`) so you can easily use this repositories' packages
- provided a helper function to easily define a flake which creates a mobile-nixos system