### PR TITLE
Add mobile.outputs data to device-specific outputs

### DIFF
--- a/doc/_support/devices/default.nix
+++ b/doc/_support/devices/default.nix
@@ -10,12 +10,15 @@ let
   # Release tools used to evaluate the devices metadata.
   mobileReleaseTools = (import ../../../lib/release-tools.nix { inherit pkgs; });
   inherit (mobileReleaseTools) all-devices;
-  inherit (mobileReleaseTools.withPkgs pkgs) evalFor;
+  inherit (mobileReleaseTools.withPkgs pkgs) evalWithConfiguration;
 
   devicesDir = ../../../devices;
   devicesInfo = symlinkJoin {
     name = "devices-metadata";
-    paths = (map (device: (evalFor device).config.mobile.outputs.device-metadata) all-devices);
+    # The `allowUnfree` here comes from consuming `mobile.outputs` options
+    # which can *include* an unfree derivation, but the derivation is never
+    # actually being built.
+    paths = (map (device: (evalWithConfiguration { nixpkgs.config.allowUnfree = true; } device).config.mobile.outputs.device-metadata) all-devices);
   };
 in
 

--- a/doc/_support/options/generate-options-listing.rb
+++ b/doc/_support/options/generate-options-listing.rb
@@ -19,6 +19,13 @@ options = JSON.parse(File.read(ENV["optionsJSON"]))
     v["declarations"].any? {|path| path.match(/^#{$root}/)}
   end
 
+if options.keys.any? { |k| k.match(/^mobile\.outputs/) }
+  $stderr.puts "The options listing unexpectedly contains `mobile.outputs` options."
+  $stderr.puts "This is likely happening when adding `mobile.outputs` options without marking them `internal` or `visible = false;`."
+  $stderr.puts "Bailing!"
+  exit 1
+end
+
 if options.keys.include?("nixpkgs.system")
   $stderr.puts "The options listing unexpectedly contains NixOS options."
   $stderr.puts "Bailing!"

--- a/modules/devices-metadata.nix
+++ b/modules/devices-metadata.nix
@@ -1,12 +1,45 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, options, pkgs, ... }:
 
 let
   inherit (config) mobile;
   inherit (lib)
+    filterAttrsRecursive
+    isDerivation
+    mapAttrsRecursiveCond
     mkOption
     types
   ;
   inherit (mobile.device) identity;
+
+  isOption = v: (v ? _type);
+  keepExposedAndDefined = mapAttrsRecursiveCond (v: !(isOption v)) (attr: opt:
+      # We collect the descriptions for defined values that are derivations
+      # Only if they're not internal.
+      if (opt ? internal && opt.internal) || !(opt.isDefined && isDerivation opt.value) then null else
+      opt
+    )
+  ;
+  # Compacting may need to be used twice to evict newly-emptied attrsets.
+  compactAttrs = filterAttrsRecursive (k: v:
+    v != {} && v != null
+  );
+  keepDescription = mapAttrsRecursiveCond (v: !(isOption v)) (attr: opt: opt.description);
+
+  # Output attributes we want to expose in the documentation.
+  desiredAttrs = (compactAttrs (compactAttrs (keepExposedAndDefined options.mobile.outputs)));
+
+  # Descriptions for the exposed attributes.
+  outputDescriptions = keepDescription desiredAttrs;
+
+  # Options attrset with only the output equivalent to the default attribute kept.
+  defaultOutput' = compactAttrs (compactAttrs (filterAttrsRecursive (k: v:
+    !(isOption v) || (
+      (v ? value && v.value == options.mobile.outputs.default.value)
+    )
+  ) desiredAttrs));
+
+  # Description for the default attribute; same shape as outputDescriptions.
+  defaultOutput = keepDescription defaultOutput';
 in
 {
   options = {
@@ -37,6 +70,8 @@ in
       };
       identifier = mobile.device.name;
       fullName = "${identity.manufacturer} ${identity.name}";
+      inherit defaultOutput;
+      inherit outputDescriptions;
     });
   };
 }


### PR DESCRIPTION
See #406.

This is blocked on memory use ballooning from 2GiB to 10GiB when building the documentation.

Some superficial look at it seems to show that building all the `device-metadata` in a single evaluation is costly in memory. I don't have the required knowledge to understand how to reduce memory usage.

Replacing `desiredAttrs` by `{}` goes back to previous memory use.

"Cheating" in `keepExposedAndDefined` and returning a "fake" option with only the right fields inherited still consumes ~7GiB; in fact even returning `{}` instead of the "full" `opt` in `keepExposedAndDefined` consumes ~7GiB.