### PR TITLE
android: fix system zip name

### DIFF
--- a/modules/system-types/android/flashable-zip.nix
+++ b/modules/system-types/android/flashable-zip.nix
@@ -38,7 +38,7 @@ let
   };
 
   android-flashable-system = make-flashable-zip {
-    name = "flashable-${device.name}-boot.zip";
+    name = "flashable-${device.name}-system.zip";
     script = ''
       ${android-flashable-fragment-assertDevice}
       ${android-flashable-fragment-burnSystem}


### PR DESCRIPTION
This allows me to build the system and bootimg in a "linkFarmFromDrvs" to build with a single command.

This is presumably a copy/paste mistake from writing the bootimg part, copying it to system and then missing replacing in the filename.