### PR TITLE
pinephone/pinephone-keyboard: init at 1.2

### DIFF
--- a/devices/pine64-pinephone/overlay/default.nix
+++ b/devices/pine64-pinephone/overlay/default.nix
@@ -1,5 +1,6 @@
 final: super: {
   pine64-pinephone = {
     qfirehose = final.callPackage ./qfirehose {};
+    pinephone-keyboard = final.callPackage ./pinephone-keyboard {};
   };
 }

--- a/devices/pine64-pinephone/overlay/pinephone-keyboard/default.nix
+++ b/devices/pine64-pinephone/overlay/pinephone-keyboard/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchgit, php, python3, sdcc }:
+
+stdenv.mkDerivation rec {
+  pname = "pinephone-keyboard";
+  version = "1.2";
+
+  src = fetchgit {
+    url = "https://megous.com/git/pinephone-keyboard";
+    rev = "693cf5ae861182e814b86d8b24df1b77b2512cd0";
+    sha256 = "sha256-iTeFXeDe7jog2QEgKBCoX2dht5W8lzfiVryP2nmWpf0=";
+  };
+
+  patches = [
+    ./version.patch
+  ];
+
+  nativeBuildInputs = [ php python3 sdcc ];
+
+  makeFlags = [ "all" ];
+
+  postPatch = ''
+    patchShebangs firmware/build.sh
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/pinephone-keyboard
+    cp build/ppkb-* $out/bin
+    cp build/*.bin $out/share/pinephone-keyboard
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Userspace tools and firmware for the PinePhone keyboard";
+    homepage = "https://xff.cz/git/pinephone-keyboard";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.zhaofengli ];
+    platforms = platforms.unix;
+  };
+}

--- a/devices/pine64-pinephone/overlay/pinephone-keyboard/version.patch
+++ b/devices/pine64-pinephone/overlay/pinephone-keyboard/version.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index 57def23..dfd1591 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,4 +1,4 @@
+-VERSION := $(shell git describe) $(shell git log -1 --format=%cd --date=iso)
++VERSION := "nixpkgs"
+ 
+ OUT ?= build/
+ CFLAGS ?= -O2 -g0
+diff --git a/firmware/build.sh b/firmware/build.sh
+index 383832f..6dd9c68 100755
+--- a/firmware/build.sh
++++ b/firmware/build.sh
+@@ -24,7 +24,7 @@ sdcc \
+ 	--code-size 0x2000 --code-loc 0x2130 \
+ 	-Wl-bIVECT=0x2000 \
+ 	-I. \
+-	-DFW_REVISION_STR="\"$(git describe) $(git log -1 --format=%cd --date=iso)\"" \
++	-DFW_REVISION_STR="\"nixpkgs\"" \
+ 	-DCONFIG_STOCK_FW=1 \
+ 	build/stock-ivt.rel main.c \
+ 	-o build/fw-stock.ihx
+@@ -38,7 +38,7 @@ sdcc \
+ 	-mmcs51 --iram-size 255 --xram-size 2048 \
+ 	--code-size 0x4000 --code-loc 0x4000 \
+ 	-I. \
+-	-DFW_REVISION_STR="\"$(git describe) $(git log -1 --format=%cd --date=iso)\"" \
++	-DFW_REVISION_STR="\"nixpkgs\"" \
+ 	-DCONFIG_STOCK_FW=0 \
+ 	-DCONFIG_USB_STACK=0 \
+ 	-DCONFIG_DEBUG_LOG=1 \


### PR DESCRIPTION
<details>
<summary>Old description</summary>

`fetchurl` needs to be used since it's a bundle of multiple commits and `fetchpatch`'s normalization will ruin the ordering. For PinePhone Pro, [this DT patch](https://gist.github.com/zhaofengli/5378d1a207e27eefaafe401edf16321b) is required but it doesn't work well at the moment (keypresses are inconsistent) and more investigation is needed.
</details>