### PR TITLE
overlay/kernel-builder: use modules_install as a install target when kernel is modular

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -409,6 +409,7 @@ stdenv.mkDerivation (inputArgs // {
   installTargets =
     if isCompressed != false then [ "zinstall" ] else [ "install" ]
     ++ installTargets
+    ++ optional isModular "modules_install"
   ;
 
   preInstall = optionalString enableCombiningBuildAndInstallQuirk ''


### PR DESCRIPTION
Shouldn't affect anything currently in-repo really, but it does make sense to do IMO.