### PR TITLE
examples/gnome: init

### DIFF
--- a/examples/gnome/README.md
+++ b/examples/gnome/README.md
@@ -1,0 +1,10 @@
+## Building
+
+The stage-2 needs to be built natively on the target architecture (armv7 on
+armv7, aarch64 on aarch64).
+
+(Though the tooling will try to build it through cross-compilation!)
+
+## :warning: Warning :warning:
+
+This configuration includes patches to GNOME that are still very work-in-progress. For more info, please refer to this article: https://blogs.gnome.org/shell-dev/2022/09/09/gnome-shell-on-mobile-an-update/

--- a/examples/gnome/configuration.nix
+++ b/examples/gnome/configuration.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkForce;
+  system_type = config.mobile.system.type;
+
+  defaultUserName = "alice";
+in
+{
+  imports = [
+    ./gnome.nix
+  ];
+
+  config = {
+    users.users."${defaultUserName}" = {
+      isNormalUser = true;
+      password = "1234";
+      extraGroups = [
+        "dialout"
+        "feedbackd"
+        "networkmanager"
+        "video"
+        "wheel"
+      ];
+    };
+  };
+}

--- a/examples/gnome/default.nix
+++ b/examples/gnome/default.nix
@@ -1,0 +1,14 @@
+{ device ? null
+, pkgs ? (import ../../pkgs.nix {})
+}@args':
+let args = args' // { inherit pkgs; }; in
+
+import ../../lib/eval-with-configuration.nix (args // {
+  configuration = [ (import ./configuration.nix) ];
+  additionalHelpInstructions = ''
+    You can build the `-A outputs.default` attribute to build the default output
+    for your device.
+
+     $ nix-build examples/gnome --argstr device ${device} -A outputs.default
+  '';
+})

--- a/examples/gnome/gnome.nix
+++ b/examples/gnome/gnome.nix
@@ -1,0 +1,40 @@
+#
+# This file represents safe opinionated defaults for a basic GNOME mobile system.
+#
+# NOTE: this file and any it imports **have** to be safe to import from
+#       an end-user's config.
+#
+{ config, lib, pkgs, options, ... }:
+
+{
+  mobile.beautification = {
+   silentBoot = lib.mkDefault true;
+   splash = lib.mkDefault true;
+  };
+
+  nixpkgs.overlays = [
+    (import ./overlay)
+  ];
+
+  services.xserver.enable = true;
+  services.xserver.desktopManager.gnome = {
+    enable = true;
+    extraGSettingsOverrides = ''
+      [org.gnome.mutter.dynamic-workspaces]
+      enabled=true
+    '';
+    extraGSettingsOverridePackages = [ pkgs.gnome.mutter ];
+  };
+  services.xserver.displayManager.gdm.enable = true;
+
+  programs.calls.enable = true;
+
+  environment.systemPackages = with pkgs; [
+    chatty              # IM and SMS
+    epiphany            # Web browser
+    gnome-console       # Terminal
+    megapixels          # Camera
+  ];
+
+  hardware.sensor.iio.enable = true;
+}

--- a/examples/gnome/overlay/default.nix
+++ b/examples/gnome/overlay/default.nix
@@ -1,0 +1,40 @@
+self: super:
+{
+    gnome = super.gnome.overrideScope' (gself: gsuper: {
+      gnome-shell = gsuper.gnome-shell.overrideAttrs (old: {
+         version = "43.1-mobile";
+         src = super.fetchgit {
+           url = "https://gitlab.gnome.org/verdre/gnome-shell.git";
+           rev = "4ef0db259a1815d00656c3adab89df14f272067e";
+           sha256 = "pIBJFyg1XDVrZdPhbDYdSGrDEwa1xTT4gSnF7z7tLpw=";
+         };
+         postPatch = ''
+           patchShebangs src/data-to-c.pl
+       
+           # We can generate it ourselves.
+           rm -f man/gnome-shell.1
+         '';
+         postFixup = ''
+            # The services need typelibs.
+            for svc in org.gnome.ScreenSaver org.gnome.Shell.Extensions org.gnome.Shell.Notifications org.gnome.Shell.Screencast; do
+              wrapGApp $out/share/gnome-shell/$svc
+            done
+         '';
+      });
+
+      mutter = gsuper.mutter.overrideAttrs (old: {
+          version = "43.1-mobile";
+          src = super.fetchgit {
+            url = "https://gitlab.gnome.org/verdre/mutter.git";
+            rev = "4e6674075cfd7e644da14837a661ed3a1fb0395b";
+            sha256 = "AgisT14I22q8VEkc7IionZmZi89KMEHBVwQLVdL22Ck=";
+          };
+          patches = [ ./sysprof.patch ];
+          buildInputs = old.buildInputs ++ [
+            super.gtk4
+          ];
+          outputs = [ "out" "dev" "man" ];
+          postFixup = '' '';
+      });
+    });
+}

--- a/examples/gnome/overlay/sysprof.patch
+++ b/examples/gnome/overlay/sysprof.patch
@@ -1,0 +1,55 @@
+From 285a5a4d54ca83b136b787ce5ebf1d774f9499d5 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Fri, 12 Aug 2022 23:57:31 +0200
+Subject: [PATCH] build: Fix Sysprof interface path with split sysprof package
+
+When sysprof-4 and libsysprof-capture-4 are installed into different
+prefixes, such as with Nix package manager, the D-Bus interfaces
+are likely not discoverable from the latter package.
+---
+ cogl/meson.build | 2 +-
+ meson.build      | 9 ++++++++-
+ src/meson.build  | 6 ------
+ 3 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/cogl/meson.build b/cogl/meson.build
+index a87cd18235..e73f1a8f9b 100644
+--- a/cogl/meson.build
++++ b/cogl/meson.build
+@@ -31,7 +31,7 @@ cogl_pkg_private_deps = [
+ 
+ if have_profiler
+   cogl_pkg_private_deps += [
+-    sysprof_dep,
++    libsysprof_capture_dep,
+   ]
+ endif
+ 
+diff --git a/meson.build b/meson.build
+index 739b249a84..9d1ab0c2f1 100644
+--- a/meson.build
++++ b/meson.build
+@@ -385,7 +385,7 @@ endif
+ have_profiler = get_option('profiler')
+ if have_profiler
+   # libsysprof-capture support
+-  sysprof_dep = dependency('sysprof-capture-4',
++  libsysprof_capture_dep = dependency('sysprof-capture-4',
+     required: true,
+     default_options: [
+       'enable_examples=false',
+@@ -398,6 +398,13 @@ if have_profiler
+     ],
+     fallback: ['sysprof', 'libsysprof_capture_dep'],
+   )
++
++  if libsysprof_capture_dep.type_name() == 'pkgconfig'
++    sysprof_dep = dependency('sysprof-4')
++    sysprof_dbus_interfaces_dir = join_paths(sysprof_dep.get_pkgconfig_variable('datadir'), 'dbus-1', 'interfaces')
++  else
++    sysprof_dbus_interfaces_dir = join_paths(mutter_srcdir, 'subprojects', 'sysprof', 'src')
++  endif
+ endif
+ 
+ required_functions = [
+GitLab


### PR DESCRIPTION
Provides a GNOME mobile example using a patched version of `gnome-shell` and `mutter` mentioned in the GNOME blog here: https://blogs.gnome.org/shell-dev/2022/09/09/gnome-shell-on-mobile-an-update/.

Tested build on oneplus-fajita
```
export NIXPKGS_ALLOW_UNFREE=1
nix-build examples/gnome --argstr device oneplus-fajita -A outputs.android-fastboot-images
```
The image boots with a usable GNOME mobile interface.