### PR TITLE
doc: explain the bin folder at the repo root

### DIFF
--- a/doc/porting-guide.adoc
+++ b/doc/porting-guide.adoc
@@ -11,6 +11,10 @@ In a nutshell, the basic steps are:
 
 == Kernel configuration
 
+The `bin/` folder containing the following scripts is located at the root of the
+mobile-nixos git repository and uses a `#!/usr/bin/env nix-shell` shebang in
+order to run with their dependencies.
+
 The kernel can be configured using the following command, where `$DEVICE` is
 the device name.
 


### PR DESCRIPTION
Explains the repo root `bin/` folder and how it works, otherwise this knowledge is assumed and confuses first time users/contributors.