### PR TITLE
Add maintainer field to devices

### DIFF
--- a/devices/oneplus-enchilada/default.nix
+++ b/devices/oneplus-enchilada/default.nix
@@ -22,4 +22,8 @@
   mobile.device.firmware = pkgs.callPackage ./firmware {};
 
   mobile.system.android.device_name = "OnePlus6";
+
+  mobile.device.maintainers = [
+    lib.maintainers.samueldr
+  ];
 }

--- a/devices/oneplus-fajita/default.nix
+++ b/devices/oneplus-fajita/default.nix
@@ -11,7 +11,7 @@
     manufacturer = "OnePlus";
   };
   # If anyone wants to step to the plate and support it, please do.
-  mobile.device.supportLevel = "best-effort";
+  mobile.device.supportLevel = "supported";
 
   mobile.hardware = {
     ram = 1024 * 8;
@@ -23,4 +23,8 @@
   mobile.device.firmware = pkgs.callPackage ../oneplus-enchilada/firmware {};
 
   mobile.system.android.device_name = "OnePlus6T";
+
+  mobile.device.maintainers = [
+    pkgs.mobile-nixos.lib.maintainers.matthewcroughan
+  ];
 }

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -1,0 +1,21 @@
+/* List of Mobile NixOS maintainers.
+
+If you are not yet a Nixpkgs maintainer, would like to only be a Mobile NixOS
+maintainer or want to add Mobile NixOS specific details to your maintainership,
+please add to this file.
+
+This file re-uses the pattern from
+https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix,
+see it for more details.
+
+Name and contact method such as email, matrix or github are required.
+*/
+{
+  matthewcroughan = {
+    email = "mobile-nixos@nix.how";
+    github = "MatthewCroughan";
+    githubId = 26458780;
+    name = "Matthew Croughan";
+  };
+}
+/* Keep the list alphabetically sorted. */

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -61,6 +61,14 @@ in
         Support level for the device.
       '';
     };
+
+    maintainers = mkOption {
+      type = (types.listOf types.attrs);
+      default = [ { } ];
+      description = lib.mdDoc ''
+        List of maintainers for the device
+      '';
+    };
   };
 
   config = mkMerge [

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -159,6 +159,8 @@ in
 
       mkLVGUIApp = callPackage ./mobile-nixos/lvgui {};
 
+      lib.maintainers = import ../lib/maintainers.nix;
+
       cross-canary-test = callPackage ./mobile-nixos/cross-canary/test.nix {};
       cross-canary-test-static = self.pkgsStatic.callPackage ./mobile-nixos/cross-canary/test.nix {};
     };


### PR DESCRIPTION
Closes https://github.com/NixOS/mobile-nixos/issues/335 and adds maintainers to two devices (oneplus-enchilada and oneplus-fajita). If a user is not a maintainer in Nixpkgs via `lib.maintainers` then they can add their own unique maintainer attribute set in `lib/maintainers.nix` which copies the patterns from https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix. It is then accessible in the `mobile-nixos` set in the overlay like `pkgs.mobile-nixos.lib.maintainers` rather than `pkgs.lib.maintainers`.