### PR TITLE
Fix and update kernel normalization tooling

### DIFF
--- a/bin/kernel-normalize-all
+++ b/bin/kernel-normalize-all
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+FAILED=()
+
+maybe_normalize() {
+	# Prevent needlessly updating the config file when only compiler
+	# information is updated (e.g. native vs. cross-compiled).
+	if ! bin/kernel-normalize-config --only-check "$1"; then
+		if ! bin/kernel-normalize-config "$1"; then
+			FAILED+=("$1")
+		fi
+	fi
+	:
+}
+
+ROOT="$(cd "${BASH_SOURCE[0]%/*}"/..; pwd)"
+cd "$ROOT"
+
+for device in devices/*/default.nix; do
+	device="${device%/*}"
+	if [[ "$device" == "devices/uefi-x86_64" ]]; then
+		continue
+	fi
+	maybe_normalize "$device"
+done
+maybe_normalize support/additional-devices/uefi-x86_64-with-kernel
+
+echo "These devices failed to normalize:"
+for device in "${FAILED[@]}"; do
+	printf "  - %s\n" "$device"
+done

--- a/bin/kernel-normalize-config
+++ b/bin/kernel-normalize-config
@@ -37,17 +37,26 @@ end.to_h
 
 DEVICE = other_args.shift
 
-@file =
+args =
   # Is the device a path?
   if DEVICE.match(%r{/})
-    Dir.glob(File.join(DEVICE, "kernel", "config.*")).sort.first
+    ["--arg", "device", DEVICE]
   else
-    Dir.glob(File.join(Dir.pwd, "devices", DEVICE, "kernel", "config.*")).sort.first
+    ["--argstr", "device", DEVICE]
   end
 
-if params["file"]
-  @file = params.delete("file")
-end
+@file =
+  if params["file"]
+    params.delete("file")
+  else
+    $stderr.puts "\nGetting config file path to update..."
+    `#{[
+      "nix-instantiate",
+      "--eval",
+      *args,
+      "--attr", "config.mobile.boot.stage-1.kernel.package.configfile",
+    ].shelljoin}`.strip
+  end
 
 unless @file and File.exists?(@file)
   $stderr.puts "Kernel config file not found."
@@ -75,19 +84,13 @@ unless @file
   exit 1
 end
 
-arg =
-  # Is the device a path?
-  if DEVICE.match(%r{/})
-    ["--arg", "device", DEVICE]
-  else
-    ["--argstr", "device", DEVICE]
-  end
+$stderr.puts "\nNOTE: This will update '#{@file}'\n\n"
 
 Dir.chdir(ROOT) do
   result = `#{[
     "nix-build",
     "--no-out-link",
-    *arg,
+    *args,
     "-A", "config.mobile.boot.stage-1.kernel.package.normalizedConfig"
   ].shelljoin}`.strip
 

--- a/bin/kernel-normalize-config
+++ b/bin/kernel-normalize-config
@@ -40,10 +40,13 @@ DEVICE = other_args.shift
 args =
   # Is the device a path?
   if DEVICE.match(%r{/})
-    ["--arg", "device", DEVICE]
+    ["--arg", "device", DEVICE.sub(%r{/+$}, "")]
   else
     ["--argstr", "device", DEVICE]
   end
+
+# 
+args << File.join(ROOT, "default.nix")
 
 @file =
   if params["file"]
@@ -86,16 +89,14 @@ end
 
 $stderr.puts "\nNOTE: This will update '#{@file}'\n\n"
 
-Dir.chdir(ROOT) do
-  result = `#{[
-    "nix-build",
-    "--no-out-link",
-    *args,
-    "-A", "config.mobile.boot.stage-1.kernel.package.normalizedConfig"
-  ].shelljoin}`.strip
+result = `#{[
+  "nix-build",
+  "--no-out-link",
+  *args,
+  "-A", "config.mobile.boot.stage-1.kernel.package.normalizedConfig"
+].shelljoin}`.strip
 
-  # We "cat" into the file to ensure we don't copy the store path access rights.
-  File.write(@file, File.read(result))
-end
+# We "cat" into the file to ensure we don't copy the store path access rights.
+File.write(@file, File.read(result))
 
 # vim: ft=ruby

--- a/bin/kernel-normalize-config
+++ b/bin/kernel-normalize-config
@@ -13,9 +13,10 @@ require "shellwords"
 ROOT = File.join(__dir__, "..")
 
 def usage()
-  puts "Usage: bin/kernel-normalize-config [--file=config.path] <device_name>"
+  puts "Usage: bin/kernel-normalize-config [--file=config.path] --only-check <device_name>"
   puts ""
   puts " --file=path/to/kernel/config.file -- detected automatically if not present."
+  puts " --only-check"
 end
 
 # Poor approximation to arguments parsing.
@@ -35,6 +36,14 @@ params = params.map do |param|
   [k, v]
 end.to_h
 
+ONLY_CHECK =
+  if params["only-check"] then
+    true
+    params.delete("only-check")
+  else
+    false
+  end
+
 DEVICE = other_args.shift
 
 args =
@@ -51,26 +60,10 @@ args << File.join(ROOT, "default.nix")
 @file =
   if params["file"]
     params.delete("file")
-  else
-    $stderr.puts "\nGetting config file path to update..."
-    `#{[
-      "nix-instantiate",
-      "--eval",
-      *args,
-      "--attr", "config.mobile.boot.stage-1.kernel.package.configfile",
-    ].shelljoin}`.strip
   end
 
-unless @file and File.exists?(@file)
-  $stderr.puts "Kernel config file not found."
-  $stderr.puts "Please provide path to the config file with `--file=...`."
-  $stderr.puts
-  usage
-  exit 1
-end
-
 unless params.empty?
-  $stderr.puts "Unknown parameters #{params.join(", ")}."
+  $stderr.puts "Unknown parameters #{params.keys.join(", ")}."
   usage
   exit 1
 end
@@ -81,22 +74,60 @@ unless other_args.empty?
   exit 1
 end
 
-unless @file
-  $stderr.puts "Could not find kernel configuration file for #{DEVICE}."
-  usage
-  exit 1
+unless ONLY_CHECK
+  unless @file
+    $stderr.puts "\nGetting config file path to update..."
+    @file = 
+      `#{[
+        "nix-instantiate",
+        "--eval",
+        *args,
+        "--attr", "config.mobile.boot.stage-1.kernel.package.configfile",
+      ].shelljoin}`.strip
+  end
+
+  unless @file and File.exists?(@file)
+    $stderr.puts "Kernel config file not found."
+    $stderr.puts "Please provide path to the config file with `--file=...`."
+    $stderr.puts
+    usage
+    exit 1
+  end
+
+  unless @file
+    $stderr.puts "Could not find kernel configuration file for #{DEVICE}."
+    usage
+    exit 1
+  end
+
+  $stderr.puts "\nNOTE: This will update '#{@file}'\n\n"
 end
 
-$stderr.puts "\nNOTE: This will update '#{@file}'\n\n"
+attr =
+  if ONLY_CHECK
+    "config.mobile.boot.stage-1.kernel.package.validatedConfig"
+  else
+    "config.mobile.boot.stage-1.kernel.package.normalizedConfig"
+  end
 
 result = `#{[
   "nix-build",
   "--no-out-link",
   *args,
-  "-A", "config.mobile.boot.stage-1.kernel.package.normalizedConfig"
+  "-A", attr
 ].shelljoin}`.strip
 
-# We "cat" into the file to ensure we don't copy the store path access rights.
-File.write(@file, File.read(result))
+if ONLY_CHECK
+  if $?.success?
+    $stderr.puts "Configuration passed."
+    exit 0
+  else
+    $stderr.puts "Configuration is stale."
+    exit 1
+  end
+else
+  # We "cat" into the file to ensure we don't copy the store path access rights.
+  File.write(@file, File.read(result))
+end
 
 # vim: ft=ruby

--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -334,7 +334,7 @@ stdenv.mkDerivation (inputArgs // {
       echo "ERROR: $buildRoot/.config : file exists."
       echo "       The kernel source tree must not contain a .config file."
       echo "       Remove the .config file and provide it as an input for the derivation."
-      exit 1
+      exit 4
     fi
 
     # Catting so we can write to the config file
@@ -408,7 +408,7 @@ stdenv.mkDerivation (inputArgs // {
           echo '       Use the `bin/kernel-normalize-config` tool to refresh the configuration.'
           echo "       Don't forget to make sure the changed configuration options are good!"
           printf "\n"
-          exit 1
+          exit 3
         fi
         rm -v $buildRoot/.tmp.config{.old,}
       fi

--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -544,6 +544,20 @@ stdenv.mkDerivation (inputArgs // {
 
   passthru = let
     baseVersion = lib.head (lib.splitString "-rc" version);
+    configUpdater = attrs: kernelDerivation.overrideAttrs({ ... }: ({
+      # This is because we'll use the new output!
+      # So skip the checks.
+      forceNormalizedConfig = false;
+      # Ensure we get new config elements from structured config.
+      updateConfigFromStructuredConfig = true;
+      # Copy the produced config
+      installPhase = ''
+        cp .config $out
+      '';
+      # Skip other phases entirely
+      buildPhase = ":";
+      fixupPhase = ":";
+    } // attrs));
   in {
     # Used by consumers of the kernel derivation to configure the build
     # appropriately for different quirks.
@@ -556,15 +570,14 @@ stdenv.mkDerivation (inputArgs // {
     # Used by consumers to refer to the kernel build product.
     file = kernelFile;
 
-    # Derivation with the as-built normalized kernel config
-    normalizedConfig = kernelDerivation.overrideAttrs({ ... }: {
-      forceNormalizedConfig = false;
-      updateConfigFromStructuredConfig = true;
-      buildPhase = "echo Skipping build phase...";
-      installPhase = ''
-        cp .config $out
-      '';
-    });
+    # Used to update the config.
+    normalizedConfig = configUpdater {};
+
+    # Used to fail CI when configs don't pass anymore.
+    validatedConfig  = configUpdater {
+      updateConfigFromStructuredConfig = false;
+      forceNormalizedConfig = true;
+    };
 
     # Patching over this configuration to expose menuconfig.
     menuconfig = kernelDerivation.overrideAttrs({nativeBuildInputs ? [] , ...}: {


### PR DESCRIPTION
This is part of a bigger change, but a small digestible and complete bit.

 - Adds a `normalize-all` helper to normalize all.
 - Makes it unneeded to use `--file=` in most situations (including families!)
 - Allows only checking for normalization issue (used to not needlessly update when only compiler info changes)

Note that the fix that makes it better at "guessing" the config file path also means it works better with out-of-tree devices... Not sure it'll really help anyone, but if you're "*misusing*" Mobile NixOS to e.g. write to a modem stick (*cough* @colemickens) it should be easier to maintain within its own repo.

