### PR TITLE
Make kernel config checking less strict

### DIFF
--- a/examples/common-configuration.nix
+++ b/examples/common-configuration.nix
@@ -1,0 +1,6 @@
+{ lib, ... }:
+
+{
+  # Ensures all example systems float up normalization issues by default.
+  mobile.boot.stage-1.kernel.useStrictKernelConfig = lib.mkDefault true;
+}

--- a/examples/hello/configuration.nix
+++ b/examples/hello/configuration.nix
@@ -39,6 +39,7 @@ in
 {
   imports = [
     ./workaround-v4l_id-hang.nix
+    ../common-configuration.nix
   ];
 
   environment.systemPackages = with pkgs; [

--- a/examples/installer/configuration.nix
+++ b/examples/installer/configuration.nix
@@ -9,6 +9,7 @@
 
 {
   imports = [
+    ../common-configuration.nix
     ./modules/all.nix
   ];
 }

--- a/examples/phosh/configuration.nix
+++ b/examples/phosh/configuration.nix
@@ -9,6 +9,7 @@ in
 {
   imports = [
     ./phosh.nix
+    ../common-configuration.nix
   ];
 
   config = {

--- a/examples/plasma-mobile/configuration.nix
+++ b/examples/plasma-mobile/configuration.nix
@@ -11,6 +11,7 @@ in
   imports = [
     ./mobile-nixos-branding.nix
     ./plasma-mobile.nix
+    ../common-configuration.nix
   ];
 
   config = lib.mkMerge [

--- a/examples/target-disk-mode/configuration.nix
+++ b/examples/target-disk-mode/configuration.nix
@@ -23,6 +23,10 @@ let
   ;
 in
 {
+  imports = [
+    ../common-configuration.nix
+  ];
+
   mobile.boot.stage-1.tasks = [
     (# Slip an assertion here; nixos asserts only operate on `build.toplevel`.
     if !internalStorageConfigured

--- a/examples/testing/crash-before-switch-root/configuration.nix
+++ b/examples/testing/crash-before-switch-root/configuration.nix
@@ -1,6 +1,9 @@
 { config, lib, pkgs, ... }:
 
 {
+  imports = [
+    ../../common-configuration.nix
+  ];
   mobile.boot.stage-1.tasks = [ ./crash.rb ];
 
   mobile.boot.stage-1.bootConfig = {

--- a/examples/testing/nixos-integration/configuration.nix
+++ b/examples/testing/nixos-integration/configuration.nix
@@ -1,5 +1,9 @@
 { lib, ... }:
 {
+  imports = [
+    ../../common-configuration.nix
+  ];
+
   # This system is not expected to be bootable.
   fileSystems = {
     "/" = {

--- a/examples/testing/qemu-cryptsetup/configuration.nix
+++ b/examples/testing/qemu-cryptsetup/configuration.nix
@@ -52,6 +52,10 @@ let
 in
 
 {
+  imports = [
+    ../../common-configuration.nix
+  ];
+
   boot.initrd.luks.devices = {
     LUKS-MOBILE-ROOTFS = {
       device = "/dev/disk/by-uuid/${uuid}";

--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -84,6 +84,20 @@ in
         This is not using a kernelPackages attrset, but a kernel derivation directly.
       '';
     };
+    useStrictKernelConfig = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Whether or not to fail when the config file differs when built.
+
+        When building a personal configuration, this should be disabled (`false`)
+        for convenience, as it allows implicitly tracking revision updates.
+
+        When in testing scenarios (e.g. building an example system) this should
+        be enabled (`true`), as it ensures all required configuration is set
+        as expected.
+      '';
+    };
     # These options are not intended for end-user use, which is why they must
     # all be marked internal.
     # The only reason is to prevent needless rebuilds by end-users.
@@ -138,6 +152,12 @@ in
           "crc32c"
         ];
       });
+
+      nixpkgs.overlays = [(_: _: {
+        # Used to transmit the option to the kernel builder
+        # *sigh*
+        __mobile-nixos-useStrictKernelConfig = cfg.useStrictKernelConfig;
+      })];
     }
     # Logo configuration
     {

--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -62,6 +62,10 @@
 # system build.
 , systemBuild-structuredConfig ? {}
 
+# When set to true, the kernel build will be failed when the kernel
+# config differs from expected.
+, __mobile-nixos-useStrictKernelConfig ? false
+
 # Only the logo file has to be overridable; the enable/disable flags are part
 # of the builder signature such that if enabling the logo replacement causes
 # issues, it can be disabled for a particular kernel.
@@ -206,10 +210,10 @@ stdenv.mkDerivation (inputArgs // {
 
   # Allows disabling the kernel config normalization.
   # Set to false when normalizing the kernel config.
-  forceNormalizedConfig = true;
+  forceNormalizedConfig = __mobile-nixos-useStrictKernelConfig;
 
   # Allows updating the kernel config to conform to the structured config.
-  updateConfigFromStructuredConfig = false;
+  updateConfigFromStructuredConfig = !__mobile-nixos-useStrictKernelConfig;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr ]


### PR DESCRIPTION
> ***But why??*** The kernel config checking is important to ensure we run what we declare!!

Yes it is!!

This is why it's only less strict *by default*!

* * *

With this change, we change the semantics of the structure kernel config attributes, *and* make it easier for end-users to track stable versions of kernels.

Though the latter will need a bit more work (e.g. a helper to help), the former is an interesting paradigm shift.

In a user configuration, changing `mobile.kernel.structuredConfig` is now allowed, and will intrinsically affect the build. This should make it easier for end-users to play with new ideas, and then later down the line contribute a better finished set of new configurations.

As for the helper for tracking kernels? Still to be written, but I was thinking a simple option to "force" a kernel source to be changed to another package's source, or something along the line. So for example, as of right now, I would be able to configure my tablets to "track" `pkgs.linuxKernel.packages.linux_6_5` as the source, while it would still build with the Mobile NixOS tooling, and patches described there. The patches would be concatenated. For strictly-mainline devices, it makes sense to even set it as a default on updates...

... for non-strictly-mainline devices, less so, but users will be more easily able to pick the stable branch releases out of these WIP repos.

* * *

We're still using strict kernel config checks in the examples, this way we will see slip-ups when using them.