### PR TITLE
acer-lazor: init

### DIFF
--- a/devices/acer-lazor/README.adoc
+++ b/devices/acer-lazor/README.adoc
@@ -1,0 +1,42 @@
+= Acer Chromebook Spin 513
+include::_support/common.inc[]
+
+== Device-specific notes
+
+=== Developer mode
+
+For more details the link:https://chromium.googlesource.com/chromiumos/docs/+/HEAD/debug_buttons.md#Firmware-Menu-Interface[
+Firmware Menu Interface] section from the upstream documentation can be read.
+
+You will need to:
+
+. Boot in _Recovery mode_ by resetting pressing `Esc` + `Refresh (F3)` + `Power`
+. Activate Developer mode by navigating the on-screen menu
+
+Note that this is only to allow you to boot unverified images.
+
+You may want to configure other options with GBB flags. This is left as an
+exercise to the reader.
+
+=== Wi-Fi support
+
+The Wi-Fi interface requires the modem to be initialized, even on non-LTE
+devices.
+
+The modem requires currently unredistributable firmware. It has been overlaid
+in the package set as `chromeos-sc7180-unredistributable-firmware`.
+
+For the time being, you will need to manually add this to your configuration
+for Wi-Fi.
+
+[source,nix]
+----
+{ /* configuration.nix */
+  hardware.firmware = [
+    pkgs.chromeos-sc7180-unredistributable-firmware
+  ];
+}
+----
+
+You will also need to connect with an alternative connection with the
+installer, or build it with the firmware yourself.

--- a/devices/acer-lazor/default.nix
+++ b/devices/acer-lazor/default.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../families/mainline-chromeos-sc7180
+  ];
+
+  mobile.device.name = "acer-lazor";
+  mobile.device.identity = {
+    name = "Chromebook Spin 513";
+    manufacturer = "Acer";
+  };
+  mobile.device.supportLevel = "supported";
+
+  mobile.hardware = {
+    screen = {
+      width = 1920; height = 1080;
+    };
+  };
+}

--- a/examples/installer/app/lib/configuration.rb
+++ b/examples/installer/app/lib/configuration.rb
@@ -37,6 +37,8 @@ module Configuration
           return "acer-juniper"
         when /^google,krane/
           return "lenovo-krane"
+        when /^google,lazor/
+          return "acer-lazor"
         when /^google,wormdingler/
           return "lenovo-wormdingler"
         when /^google,scarlet/
@@ -71,7 +73,7 @@ module Configuration
       case identifier
       when "pine64-pinephone", "pine64-pinetab", "pine64-pinephonepro"
         return "u-boot"
-      when "acer-juniper", "lenovo-krane", "lenovo-wormdingler", "asus-dumo"
+      when "acer-juniper", "acer-lazor", "lenovo-krane", "lenovo-wormdingler", "asus-dumo"
         return "depthcharge"
       end
 
@@ -100,7 +102,7 @@ module Configuration
         when "acer-juniper", "lenovo-krane"
           # MT8183 eMMC
           File.join("/dev/disk/by-path", "platform-11230000.mmc")
-        when "lenovo-wormdingler"
+        when "acer-lazor", "lenovo-wormdingler"
           # Qualcomm 7c eMMC
           File.join("/dev/disk/by-path", "platform-7c4000.mmc")
         end


### PR DESCRIPTION
This is just like the acer-juniper, a honest proof that the sc7180 family actually works across the range of supported devices.

Not many surprises with this device, and it's just as much featured (or as not featured) as the tablet variant I have. No LTE, no special features.