### PR TITLE
examples/installer: Fix boot image refs with new image building semantics

### DIFF
--- a/examples/installer/pkgs/scripted-installer/automated-installer.rb
+++ b/examples/installer/pkgs/scripted-installer/automated-installer.rb
@@ -69,13 +69,13 @@ puts "Building the boot image..."
 case system_type
 when "u-boot"
   boot_image = Nix.build("<nixpkgs/nixos>", attr: "config.mobile.outputs.u-boot.boot-partition")
-  boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image, "*.img")).first
+  boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image)).first
 when "depthcharge"
   boot_image = Nix.build("<nixpkgs/nixos>", attr: "config.mobile.outputs.depthcharge.kpart")
-  boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image, "kpart")).first
+  boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image)).first
 when "uefi"
   boot_image = Nix.build("<nixpkgs/nixos>", attr: "config.mobile.outputs.uefi.boot-partition")
-  boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image, "*.img")).first
+  boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image)).first
 else
   raise "Cannot install for system type #{system_type}"
 end


### PR DESCRIPTION
The root cause is that in https://github.com/NixOS/mobile-nixos/pull/622 all outputs are now directly the images, so the globs obviously(?) don't refer to a valid path anymore.