### PR TITLE
Remove deprecated URL literals and unused args

### DIFF
--- a/boot/recovery-menu/default.nix
+++ b/boot/recovery-menu/default.nix
@@ -1,4 +1,4 @@
-{ lib, runCommand, mobile-nixos }:
+{ lib, mobile-nixos }:
 
 mobile-nixos.mkLVGUIApp {
   name = "boot-recovery-menu.mrb";

--- a/boot/script-loader/mruby-lvgui-native/default.nix
+++ b/boot/script-loader/mruby-lvgui-native/default.nix
@@ -1,7 +1,5 @@
 { mrbgems
 , callPackage
-, fetchFromGitHub
-, pkg-config
 , buildPackages
 
 # Configuration

--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  inherit (lib) optional optionals optionalString;
+  inherit (lib) optional optionals;
   simulatorDeps = [
     SDL2
   ];

--- a/devices/families/mainline-chromeos-sc7180/sound.nix
+++ b/devices/families/mainline-chromeos-sc7180/sound.nix
@@ -10,9 +10,6 @@
     (self: super: {
       google-trogdor-alsa-ucm = self.callPackage (
         { runCommand, fetchgit }:
-        let
-          rev = "fac4d7e17871a8e7ec1c39f58257389e9bf62f06";
-        in
         runCommand "google-trogdor-alsa-ucm" {
           src = fetchgit {
             url = "https://chromium.googlesource.com/chromiumos/overlays/board-overlays";

--- a/devices/families/sdm845-mainline/kernel/default.nix
+++ b/devices/families/sdm845-mainline/kernel/default.nix
@@ -4,7 +4,7 @@
 , ...
 }:
 
-mobile-nixos.kernel-builder rec {
+mobile-nixos.kernel-builder {
   version = "6.4.0";
   configfile = ./config.aarch64;
 

--- a/devices/motorola-potter/firmware/default.nix
+++ b/devices/motorola-potter/firmware/default.nix
@@ -1,6 +1,5 @@
 { lib
 , runCommand
-, fetchFromGitHub
 , fetchurl
 , modem ? builtins.throw ''
 

--- a/devices/motorola-potter/kernel/default.nix
+++ b/devices/motorola-potter/kernel/default.nix
@@ -1,5 +1,4 @@
 { mobile-nixos
-, stdenv
 , fetchFromGitHub
 , ...
 }:

--- a/devices/pine64-pinephonepro/kernel/default.nix
+++ b/devices/pine64-pinephonepro/kernel/default.nix
@@ -1,6 +1,5 @@
 {
   mobile-nixos
-, fetchpatch
 , fetchFromGitLab
 , ...
 }:

--- a/overlay/make_ext4fs/default.nix
+++ b/overlay/make_ext4fs/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = https://git.openwrt.org/?p=project/make_ext4fs.git;
+    homepage = "https://git.openwrt.org/?p=project/make_ext4fs.git";
     description = "Standalone fork of Android make_ext4fs utility";
     license = licenses.asl20;
     platforms = platforms.linux;

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -233,7 +233,7 @@ let
 
     meta = with lib; {
       description = "An embeddable implementation of the Ruby language";
-      homepage = https://mruby.org;
+      homepage = "https://mruby.org";
       maintainers = [ maintainers.samueldr ];
       license = licenses.mit;
       platforms = platforms.unix;

--- a/overlay/ufdt-apply-overlay/default.nix
+++ b/overlay/ufdt-apply-overlay/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     # up-upstream: https://android.googlesource.com/platform/system/libufdt/
-    homepage = https://github.com/hybris-mobian/android-platform-system-libufdt;
+    homepage = "https://github.com/hybris-mobian/android-platform-system-libufdt";
     description = "Standalone fork of platform/system/libufdt";
     platforms = platforms.linux;
     maintainers = [ maintainers.samueldr ];


### PR DESCRIPTION
- get rid of deprecated URL literals (see [RFC 45](https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md)). They break this repo's eval for me because I use an experimental Nix option that removes them.
- selectively remove unused derivation args
- remove one instance of unused rec, and two unused variables in let's