### PR TITLE
Fixed minor typo in installer script

### DIFF
--- a/examples/installer/app/windows/installation/installation.rb
+++ b/examples/installer/app/windows/installation/installation.rb
@@ -83,7 +83,7 @@ module GUI
 
       @failure_text.set_text([
         "Something went wrong when installing.",
-        "The system is in an uknown state.",
+        "The system is in an unknown state.",
         "\nReturn value: #{@installer_terminal.pane_dead_status}",
       ].join("\n"))
     end

--- a/examples/installer/pkgs/scripted-installer/disk-formatter.rb
+++ b/examples/installer/pkgs/scripted-installer/disk-formatter.rb
@@ -191,7 +191,7 @@ partition_count += 1 if $system_type == "depthcharge"
 
 if do_partitioning then
   puts ""
-  puts "Partitionning..."
+  puts "Partitioning..."
   puts ""
 
   Helpers::wipefs(disk)


### PR DESCRIPTION
This is just a nitpick, partitionning is spelled partitioning. 