### PR TITLE
further remove deprecated URL literals and unused vars

### DIFF
--- a/doc/_support/devices/default.nix
+++ b/doc/_support/devices/default.nix
@@ -1,5 +1,4 @@
 { pkgs
-, stdenv
 , glibcLocales
 , runCommand
 , symlinkJoin

--- a/examples/installer/modules/boot-closure.nix
+++ b/examples/installer/modules/boot-closure.nix
@@ -2,7 +2,6 @@
 
 let
   inherit (lib)
-    mkIf
     optionalString
   ;
   inherit (config.mobile)

--- a/examples/installer/modules/installer-gui.nix
+++ b/examples/installer/modules/installer-gui.nix
@@ -25,7 +25,7 @@ let
 in
 
 {
-  environment.systemPackages = with pkgs; [
+  environment.systemPackages = [
     installer-gui
   ];
 

--- a/examples/phosh/configuration.nix
+++ b/examples/phosh/configuration.nix
@@ -1,9 +1,6 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkForce;
-  system_type = config.mobile.system.type;
-
   defaultUserName = "alice";
 in
 {

--- a/examples/testing/nixos-integration/default.nix
+++ b/examples/testing/nixos-integration/default.nix
@@ -1,6 +1,5 @@
 { pkgs ? (import ../../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+}:
 
 let
   eval = configuration: import (pkgs.path + "/nixos") {

--- a/modules/bootloader.nix
+++ b/modules/bootloader.nix
@@ -1,11 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (config.boot) growPartition;
-  inherit (lib) mkIf mkOption optionalString types;
-  inherit (config.mobile._internal) compressLargeArtifacts;
-  inherit (pkgs) buildPackages;
-  rootfsLabel = config.mobile.generatedFilesystems.rootfs.label;
+  inherit (lib) mkIf mkOption types;
 in
 {
   options = {

--- a/modules/hardware-allwinner.nix
+++ b/modules/hardware-allwinner.nix
@@ -2,7 +2,6 @@
 
 let
   inherit (lib) mkIf mkMerge mkOption types;
-  inherit (pkgs) imageBuilder;
   cfg = config.mobile.hardware.socs;
   anyAllwinner = lib.any (v: v) [
     cfg.allwinner-a64.enable

--- a/modules/hardware-eink.nix
+++ b/modules/hardware-eink.nix
@@ -4,7 +4,6 @@ let
   inherit (lib)
     mkIf
     mkOption
-    types
   ;
   cfg = config.mobile.hardware.eink;
 in

--- a/modules/hardware-generic.nix
+++ b/modules/hardware-generic.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf mkMerge mkOption types;
+  inherit (lib) mkMerge mkOption types;
   cfg = config.mobile.hardware.socs;
 in
 {

--- a/modules/hardware-screen.nix
+++ b/modules/hardware-screen.nix
@@ -5,7 +5,6 @@ let
     mkOption
     types
   ;
-  cfg = config.mobile.hardware.screen;
 in
 {
   options.mobile.hardware.screen = {

--- a/modules/initrd-base.nix
+++ b/modules/initrd-base.nix
@@ -1,8 +1,5 @@
 { config, pkgs, ... }:
 
-let
-  cfg = config.mobile.boot.stage-1;
-in
 {
   config.mobile.boot.stage-1 = {
     extraUtils = [

--- a/modules/initrd-fail.nix
+++ b/modules/initrd-fail.nix
@@ -1,9 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf mkOption types;
-
-  cfg = config.mobile.boot.stage-1.fail;
+  inherit (lib) mkOption types;
 in
 {
   options.mobile = {

--- a/modules/initrd-fbterm.nix
+++ b/modules/initrd-fbterm.nix
@@ -5,7 +5,6 @@ let
     mkOption
     types
   ;
-  device_name = config.mobile.device.name;
   cfg = config.mobile.boot.stage-1.fbterm;
   fontsConf = pkgs.writeText "fonts.conf" ''
     <?xml version="1.0"?>

--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -4,16 +4,13 @@ let
 
   inherit (lib)
     literalExpression
-    mergeEqualOption
     mkDefault
     mkIf
     mkMerge
     mkOption
-    mkOverride
     types
   ;
   cfg = config.mobile.boot.stage-1.kernel;
-  device_config = config.mobile.device;
 
   modulesClosure = pkgs.makeModulesClosure {
     kernel = cfg.package;

--- a/modules/initrd-logs.nix
+++ b/modules/initrd-logs.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf mkMerge mkOption optionalString types;
+  inherit (lib) mkIf mkMerge mkOption types;
   inherit (config.mobile.outputs) extraUtils;
   cfg = config.mobile.boot.stage-1.bootlog;
 in

--- a/modules/initrd-network.nix
+++ b/modules/initrd-network.nix
@@ -6,8 +6,6 @@ let
     types
   ;
   cfg = config.mobile.boot.stage-1.networking;
-  IP = cfg.IP;
-  hostIP = cfg.hostIP;
 in
 {
   options.mobile.boot.stage-1.networking = {

--- a/modules/initrd-usb.nix
+++ b/modules/initrd-usb.nix
@@ -11,9 +11,6 @@ let
   ;
   inherit (config.mobile.usb) gadgetfs;
   cfg = config.mobile.boot.stage-1;
-  device_name = device_config.name;
-  device_config = config.mobile.device;
-  system_type = config.mobile.system.type;
 in
 {
   options.mobile.boot.stage-1.usb = {

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -10,7 +10,6 @@ let
     writeText
   ;
   inherit (lib)
-    concatMap
     concatStringsSep
     filter
     flatten

--- a/modules/kernel-config.nix
+++ b/modules/kernel-config.nix
@@ -229,7 +229,6 @@ in
 
       # Needed for iio sensors (e.g. accel) to be useful
       (helpers: with helpers; let
-        inherit (lib) mkMerge;
         module = yes;
       in {
         HID_SENSOR_HUB = whenAtLeast "3.7" module;

--- a/modules/quirks/wifi.nix
+++ b/modules/quirks/wifi.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkOption types mkMerge mkIf;
+  inherit (lib) mkOption types mkIf;
   cfg = config.mobile.quirks;
 in
 {

--- a/modules/recovery.nix
+++ b/modules/recovery.nix
@@ -6,7 +6,6 @@
 let
   inherit (lib)
     mkOption
-    types
   ;
 in
 {

--- a/modules/rootfs.nix
+++ b/modules/rootfs.nix
@@ -3,7 +3,6 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (config.boot) growPartition;
   inherit (lib) mkIf mkOption optionalString types;
   inherit (config.mobile._internal) compressLargeArtifacts;
   inherit (pkgs) buildPackages;

--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -6,7 +6,6 @@
 let 
   inherit (lib) mkOption types;
   inherit (config.mobile.quirks) supportsStage-0;
-  inherit (config.mobile.boot.stage-1) kernel;
 
   # A bit dirty, but actually works for what we want.
   fdt-forward = pkgs.runCommand "fdt-forward-for-initrd" {} ''

--- a/modules/system-types.nix
+++ b/modules/system-types.nix
@@ -2,7 +2,6 @@
 
 let
   inherit (lib)
-    filter
     mkIf
     mkOption
     types

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib) concatStringsSep optionalString types;
   inherit (config.mobile.outputs) recovery stage-0;
   inherit (config.mobile) device;
-  inherit (config.mobile.system.android) ab_partitions boot_as_recovery has_recovery_partition flashingMethod;
+  inherit (config.mobile.system.android) ab_partitions has_recovery_partition flashingMethod;
   inherit (stage-0.mobile.boot.stage-1) kernel;
 
   kernelPackage = kernel.package;

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -12,13 +12,11 @@ let
     removeSuffix
     types
   ;
-  inherit (pkgs) image-builder;
   inherit (config.mobile.outputs) stage-0;
   inherit (config.mobile.system.depthcharge.kpart) dtbs;
   deviceName = config.mobile.device.name;
   kernel = stage-0.mobile.boot.stage-1.kernel.package;
   kernel_file = "${kernel}/${if kernel ? file then kernel.file else pkgs.stdenv.hostPlatform.linux-kernel.target}";
-  inherit (config.mobile.generatedFilesystems) rootfs;
 
   # Name used for some image file output.
   name = "${config.mobile.configurationName}-${deviceName}";

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -4,14 +4,12 @@ let
   enabled = config.mobile.system.type == "u-boot";
 
   inherit (config.mobile.outputs) recovery stage-0;
-  inherit (pkgs) buildPackages image-builder runCommand;
+  inherit (pkgs) buildPackages runCommand;
   inherit (lib) mkBefore mkIf mkOption  types;
   cfg = config.mobile.quirks.u-boot;
-  inherit (cfg) soc;
   deviceName = config.mobile.device.name;
   kernel = stage-0.mobile.boot.stage-1.kernel.package;
   kernel_file = "${kernel}/${if kernel ? file then kernel.file else pkgs.stdenv.hostPlatform.linux-kernel.target}";
-  inherit (config.mobile.generatedFilesystems) rootfs;
   boot-partition = config.mobile.generatedFilesystems.boot.output;
 
   # Look-up table to translate from targetPlatform to U-Boot names.

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -3,14 +3,11 @@
 let
   enabled = config.mobile.system.type == "uefi";
 
-  inherit (lib) mkBefore mkEnableOption mkIf mkOption types;
-  inherit (pkgs.stdenv) hostPlatform;
-  inherit (pkgs) image-builder runCommand;
+  inherit (lib) mkBefore mkIf mkOption types;
   inherit (config.mobile.outputs) recovery stage-0;
   deviceName = config.mobile.device.name;
   kernel = stage-0.mobile.boot.stage-1.kernel.package;
   kernelFile = "${kernel}/${if kernel ? file then kernel.file else pkgs.stdenv.hostPlatform.linux-kernel.target}";
-  inherit (config.mobile.generatedFilesystems) rootfs;
   boot-partition = config.mobile.generatedFilesystems.boot.output;
 
   # Look-up table to translate from targetPlatform to U-Boot names.

--- a/modules/system-types/uefi/vm.nix
+++ b/modules/system-types/uefi/vm.nix
@@ -1,12 +1,8 @@
 { config, pkgs, lib, ... }:
 
 let
-  # This particular VM module is only enabled for the uefi system type.
-  enabled = config.mobile.system.type == "uefi";
-
-  inherit (lib) mkAfter mkIf mkMerge mkOption types;
+  inherit (lib) mkIf mkMerge mkOption types;
   inherit (config.mobile) device hardware;
-  inherit (config.mobile.boot) stage-1;
   inherit (config.mobile.generatedDiskImages) disk-image;
 
   ram  = toString hardware.ram;

--- a/overlay/adbd/default.nix
+++ b/overlay/adbd/default.nix
@@ -10,9 +10,6 @@ stdenv
 # This removes systemd socket activation (from ubports)
 # This also removes any selinux support.
 
-let
-  inherit (stdenv) targetPlatform;
-in
 stdenv.mkDerivation {
   name = "adbd";
   version = "0";

--- a/overlay/android-headers/default.nix
+++ b/overlay/android-headers/default.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation {
   name = "android-headers";
 
   src = fetchgit {
-    url = https://git.launchpad.net/android-headers;
+    url = "https://git.launchpad.net/android-headers";
     rev = "957ab6e28aea03d0cf6495f33ade9ddfff480ccc";
     sha256 = "1ma872lq46qqpfvc3x9hlcs28w7vbaaf6k5p9v114h92qsza3cm0";
   };

--- a/overlay/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
+++ b/overlay/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
@@ -1,15 +1,12 @@
 { stdenvNoCC
 , lib
-, fetchpatch
 , gptfdisk
-, buildPackages
 , utillinux
 , config
 }:
 
 let
   inherit (lib)
-    concatMapStringsSep
     concatStringsSep
     optionalString
   ;

--- a/overlay/image-builder/disk-image/partitioning-scheme/mbr/builder.nix
+++ b/overlay/image-builder/disk-image/partitioning-scheme/mbr/builder.nix
@@ -1,15 +1,11 @@
 { stdenvNoCC
 , lib
-, fetchpatch
-, buildPackages
 , utillinux
 , config
 }:
 
 let
   inherit (lib)
-    concatMapStringsSep
-    concatStringsSep
     optionalString
   ;
   inherit (config.helpers)

--- a/overlay/image-builder/disk-image/partitions.nix
+++ b/overlay/image-builder/disk-image/partitions.nix
@@ -7,10 +7,6 @@ let
     mkOption
     types
   ;
-  listEntrySubmodule = {
-    options = {
-    };
-  };
 
   inherit (config) helpers;
 

--- a/overlay/image-builder/filesystem-image/filesystem/btrfs.nix
+++ b/overlay/image-builder/filesystem-image/filesystem/btrfs.nix
@@ -11,7 +11,7 @@ let
     types
   ;
 
-  inherit (config) label sectorSize blockSize;
+  inherit (config) label;
   inherit (config.btrfs) partitionID;
 in
 {

--- a/overlay/image-builder/filesystem-image/filesystem/ext4.nix
+++ b/overlay/image-builder/filesystem-image/filesystem/ext4.nix
@@ -14,7 +14,7 @@ let
     chopDecimal
   ;
 
-  inherit (config) label sectorSize blockSize;
+  inherit (config) label;
   inherit (config.ext4) partitionID;
 
   # Bash doesn't do floating point representations. Multiplications and divisions

--- a/overlay/image-builder/filesystem-image/filesystem/squashfs.nix
+++ b/overlay/image-builder/filesystem-image/filesystem/squashfs.nix
@@ -3,15 +3,12 @@
 let
   enabled = config.filesystem == "squashfs";
   inherit (lib)
-    escapeShellArg
     mkIf
     mkMerge
     mkOption
-    optionalString
     types
   ;
 
-  inherit (config) label sectorSize blockSize;
   inherit (config.squashfs)
     compression
     compressionParams

--- a/overlay/mobile-nixos/kernel/eval-config.nix
+++ b/overlay/mobile-nixos/kernel/eval-config.nix
@@ -65,7 +65,6 @@
             let
               line = lib.escapeShellArg (mkConfigLine key item);
               lineNotSet = "# CONFIG_${key} is not set";
-              linePattern = "^CONFIG_${key}=";
               presencePattern = "CONFIG_${key}[ =]";
             in
             ''

--- a/overlay/mobile-nixos/lvgui/default.nix
+++ b/overlay/mobile-nixos/lvgui/default.nix
@@ -77,7 +77,7 @@ let
     # This is the executable name
     name = "simulator";
     applet = "${app}/${app.executablePath}";
-  }).overrideAttrs(old: rec {
+  }).overrideAttrs(old: {
     # Override the name for the derivation
     name = "simulator-for-${app.name}";
   })

--- a/overlay/mruby-builder/mruby/builder.nix
+++ b/overlay/mruby-builder/mruby/builder.nix
@@ -4,17 +4,11 @@
 
 , mruby
 , buildPackages
-
-, static ? false
 }:
 
 let
-  inherit (lib) concatStringsSep optional optionalString;
+  inherit (lib) optionalString;
 
-  isCross = stdenv.targetPlatform != stdenv.hostPlatform;
-  # FIXME: Discover from stdenv rather than from a parameter.
-  # (See comment in overlay)
-  isStatic = static;
 in
 
 # The actual builder function

--- a/overlay/mruby-builder/overlay.nix
+++ b/overlay/mruby-builder/overlay.nix
@@ -1,18 +1,9 @@
 final: super:
 
-let
-  # Errr... nothing in the `makeStatic*` stdenv adapters allow detecting
-  # whether we're doing a static build or not in a sane manner.
-  # Let's co-opt the `dontDisableStatic` attribute it overrides into a
-  # derivation, let's say, hello...
-  static = if final.hello ? dontDisableStatic then final.hello.dontDisableStatic else false;
-in
 {
   hello-mruby = final.callPackage ./hello-mruby {};
   mrbgems = final.callPackage ./mrbgems {};
   mruby = final.callPackage ./mruby {
-    builder = final.callPackage ./mruby/builder.nix {
-      inherit static;
-    };
+    builder = final.callPackage ./mruby/builder.nix { };
   };
 }

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -1,7 +1,6 @@
 self: super:
 
 let
-  fetchpatch = self.fetchpatch;
   callPackage = self.callPackage;
   # FIXME : upstream fix for .a in "lib" instead of this hack.
   # This is used to "re-merge" the split gcc package.

--- a/overlay/ply-image/default.nix
+++ b/overlay/ply-image/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   name = "ply-image";
 
   src = fetchgit {
-    url = https://chromium.googlesource.com/chromiumos/third_party/ply-image;
+    url = "https://chromium.googlesource.com/chromiumos/third_party/ply-image";
     rev = "6cf4e4cd968bb72ade54e423e2b97eb3a80c6de9";
     sha256 = "152hh9r04hjqrpfqskqh876vlf5dfqiwx719nyjq1y2qr8a9akm7";
   };

--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ let
 in
 
 # A basic shell with some tools available for porting devices.
-pkgs.mkShell rec {
+pkgs.mkShell {
   name = "nixos-mobile";
   buildInputs = with pkgs; [
     # Custom tools

--- a/support/additional-devices/uefi-x86_64-with-kernel/kernel/default.nix
+++ b/support/additional-devices/uefi-x86_64-with-kernel/kernel/default.nix
@@ -3,7 +3,7 @@
 , ...
 }:
 
-mobile-nixos.kernel-builder rec {
+mobile-nixos.kernel-builder {
   version = "6.2.0";
   configfile = ./config.x86_64;
 

--- a/support/kernel-config/configuration.nix
+++ b/support/kernel-config/configuration.nix
@@ -49,7 +49,6 @@ let
   ];
   inherit (pkgs.stdenv)
     is64bit
-    isAarch32
     isAarch64
     isx86_32
     isx86_64

--- a/support/kernel-config/default.nix
+++ b/support/kernel-config/default.nix
@@ -1,6 +1,6 @@
 { pkgs ? (import ../../pkgs.nix {})
 , device
-}@args':
+}:
 
 let
   eval = import ../../lib/eval-with-configuration.nix ({

--- a/support/kernel-config/filesystems.nix
+++ b/support/kernel-config/filesystems.nix
@@ -3,20 +3,8 @@
 let
   inherit (lib)
     mkDefault
-    mkIf
     mkMerge
-    mkOptionDefault
   ;
-
-  inherit (pkgs.stdenv)
-    is64bit
-    isAarch32
-    isAarch64
-    isx86_32
-    isx86_64
-  ;
-  isArm = isAarch64 || isAarch32;
-  isx86 = isx86_32 || isx86_64;
 
   mkDefaultIze =
     attrs:

--- a/support/kernel-config/networking.nix
+++ b/support/kernel-config/networking.nix
@@ -3,20 +3,7 @@
 let
   inherit (lib)
     mkDefault
-    mkIf
-    mkMerge
-    mkOptionDefault
   ;
-
-  inherit (pkgs.stdenv)
-    is64bit
-    isAarch32
-    isAarch64
-    isx86_32
-    isx86_64
-  ;
-  isArm = isAarch64 || isAarch32;
-  isx86 = isx86_32 || isx86_64;
 
   mkDefaultIze =
     attrs:

--- a/support/kernel-config/nixos.nix
+++ b/support/kernel-config/nixos.nix
@@ -4,18 +4,13 @@ let
   inherit (lib)
     mkDefault
     mkIf
-    mkMerge
-    mkOptionDefault
   ;
 
   inherit (pkgs.stdenv)
-    is64bit
     isAarch32
-    isAarch64
     isx86_32
     isx86_64
   ;
-  isArm = isAarch64 || isAarch32;
   isx86 = isx86_32 || isx86_64;
 
   mkDefaultIze =


### PR DESCRIPTION
This is a followup to https://github.com/NixOS/mobile-nixos/pull/661

Turns out nvim has a tab limit, so I didn't get all of them last time.

- Remove the last usages of URL literals
- All unused variables and arguments (exceptions are made for module args and lib) are removed
- Clean up a couple more unused recs

Notably, mruby-builder doesn't accept `static` anymore, because it wasn't actually used. This probably isn't intended, but this is just a cleanup (hopefully) without changing any behaviour.