### PR TITLE
qualcomm/sdm845-modem: fix uncompressed-firmware linking

### DIFF
--- a/modules/quirks/qualcomm/sdm845-modem.nix
+++ b/modules/quirks/qualcomm/sdm845-modem.nix
@@ -50,7 +50,7 @@ in
     # /run/current-system/sw/share/uncompressed-firmware/qcom/sdm845/
     # This is used by userspace components unaware of the possible xz compression.
     # See also: tqftpserv and pd-mapper patches.
-    environment.pathsToLink = [ "share/uncompressed-firmware" ];
+    environment.pathsToLink = [ "/share/uncompressed-firmware" ];
     # This package added to the environment will select a few firmware path to keep uncompressed.
     environment.systemPackages = [
       (pkgs.callPackage (


### PR DESCRIPTION
`share/uncompressed-firmware` in `pathsToLink` doesn't do anything, it has to be `/share/uncompressed-firmware`

Fixes #593