### PR TITLE
(Updated) Init: xiaomi-beryllium / POCO F1

### DIFF
--- a/devices/xiaomi-beryllium/README.adoc
+++ b/devices/xiaomi-beryllium/README.adoc
@@ -1,14 +1,22 @@
-= Xiaomi POCO F1
+= Xiaomi Pocophone F1 / POCO F1
 include::_support/common.inc[]
 
 == Device-specific notes
+
+This not an A/B device despite it having a SDM845.
+
+If you want to erase dtbo you do it like this:
+```
+ $ fastboot erase dtbo
+```
 
 === First time setup notes
 
 ==== Update firmware
 
+==== Prepare for mainline
+
 ==== Dual booting
 
-This is not supported. Refer to other non-Android Linux instructions and
-adapt as needed. Here be snapdragons.
-
+This is not really supported. 
+There are hacks to give the appearance of dual-booting for beryllium but you are a bit on your own for that.

--- a/devices/xiaomi-beryllium/README.adoc
+++ b/devices/xiaomi-beryllium/README.adoc
@@ -1,0 +1,14 @@
+= Xiaomi POCO F1
+include::_support/common.inc[]
+
+== Device-specific notes
+
+=== First time setup notes
+
+==== Update firmware
+
+==== Dual booting
+
+This is not supported. Refer to other non-Android Linux instructions and
+adapt as needed. Here be snapdragons.
+

--- a/devices/xiaomi-beryllium/default.nix
+++ b/devices/xiaomi-beryllium/default.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../families/sdm845-mainline
+  ];
+
+  mobile.device.name = "xiaomi-beryllium-tianma";
+  mobile.device.identity = {
+    name = "POCO F1";
+    manufacturer = "Xiaomi";
+  };
+  mobile.device.supportLevel = "supported";
+
+  mobile.hardware = {
+    ram = 1024 * 6;
+    screen = {
+      width = 1080; height = 2246;
+    };
+  };
+
+  mobile.device.firmware = pkgs.callPackage ./firmware {};
+
+  mobile.system.android.device_name = "beryllium";
+}

--- a/devices/xiaomi-beryllium/default.nix
+++ b/devices/xiaomi-beryllium/default.nix
@@ -7,7 +7,7 @@
 
   mobile.device.name = "xiaomi-beryllium-tianma";
   mobile.device.identity = {
-    name = "POCO F1";
+    name = "Pocophone F1 / POCO F1";
     manufacturer = "Xiaomi";
   };
   mobile.device.supportLevel = "supported";
@@ -21,5 +21,11 @@
 
   mobile.device.firmware = pkgs.callPackage ./firmware {};
 
-  mobile.system.android.device_name = "beryllium";
+  mobile.system.android = {
+    device_name = "beryllium";
+    ab_partitions = false;
+    bootimg.flash.offset_second = lib.mkForce "0x00008000"; # maybe not even used
+  };
+
+  mobile.boot.boot-control.enable = false;
 }

--- a/devices/xiaomi-beryllium/firmware/default.nix
+++ b/devices/xiaomi-beryllium/firmware/default.nix
@@ -7,8 +7,8 @@ let
   baseFw = fetchFromGitLab {
     owner = "sdm845-mainline";
     repo = "firmware-xiaomi-beryllium";
-    rev = "66ec241f43f26e8e8a2c6f18858c92f1a7fb16e4";
-    sha256 = "sha256-WhzxM7oooFNbMEQE2OQDFmTTsbvHpuxUtxYJYcPE/7E=";
+    rev = "9ce691fb2e629476a33e037bdcd039cd7e8c5a6c";
+    sha256 = "sha256-R/x7LxDyPU3s30y2PJNw72vo7wAA3Di8Iy61syffEKE=";
   };
 in runCommand "xiaomi-sdm845-firmware" { inherit baseFw; } ''
   mkdir -p $out/lib/firmware

--- a/devices/xiaomi-beryllium/firmware/default.nix
+++ b/devices/xiaomi-beryllium/firmware/default.nix
@@ -8,7 +8,7 @@ let
     owner = "sdm845-mainline";
     repo = "firmware-xiaomi-beryllium";
     rev = "66ec241f43f26e8e8a2c6f18858c92f1a7fb16e4";
-    sha256 = "sha256-7CaXWOpao+vuFA7xknzbLml2hxTlmuzFCEM99aLD2uk=";
+    sha256 = "sha256-WhzxM7oooFNbMEQE2OQDFmTTsbvHpuxUtxYJYcPE/7E=";
   };
 in runCommand "xiaomi-sdm845-firmware" { inherit baseFw; } ''
   mkdir -p $out/lib/firmware

--- a/devices/xiaomi-beryllium/firmware/default.nix
+++ b/devices/xiaomi-beryllium/firmware/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, fetchFromGitLab
+, runCommand
+}:
+
+let
+  baseFw = fetchFromGitLab {
+    owner = "sdm845-mainline";
+    repo = "firmware-xiaomi-beryllium";
+    rev = "66ec241f43f26e8e8a2c6f18858c92f1a7fb16e4";
+    sha256 = "sha256-7CaXWOpao+vuFA7xknzbLml2hxTlmuzFCEM99aLD2uk=";
+  };
+in runCommand "xiaomi-sdm845-firmware" { inherit baseFw; } ''
+  mkdir -p $out/lib/firmware
+  cp -r $baseFw/lib/firmware/* $out/lib/firmware/
+  chmod +w -R $out
+  # rm -rf $out/lib/firmware/postmarketos
+  # cp -r $baseFw/lib/firmware/postmarketos/* $out/lib/firmware
+''

--- a/devices/xiaomi-beryllium/firmware/default.nix
+++ b/devices/xiaomi-beryllium/firmware/default.nix
@@ -14,6 +14,4 @@ in runCommand "xiaomi-sdm845-firmware" { inherit baseFw; } ''
   mkdir -p $out/lib/firmware
   cp -r $baseFw/lib/firmware/* $out/lib/firmware/
   chmod +w -R $out
-  # rm -rf $out/lib/firmware/postmarketos
-  # cp -r $baseFw/lib/firmware/postmarketos/* $out/lib/firmware
 ''


### PR DESCRIPTION
#560 with a few additional changes. (Might add more commits if I notice something while daily-driving.)
Most notably removal of boot-control.service which would fail since this is not an A/B device:
```sh
warning: the following units failed: boot-control.service

× boot-control.service - Mark boot as successful
     Loaded: loaded (/etc/systemd/system/boot-control.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Thu 2023-12-28 11:44:19 UTC; 531ms ago
    Process: 92385 ExecStart=/nix/store/ng1gkkgllfgk5izwbq89g035c9qydgyf-unit-script-boot-control-start/bin/boot-control-start (code=exited, status=1/FAILURE)
   Main PID: 92385 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
        CPU: 150ms

Dec 28 11:44:19 nixos boot-control-start[92386]:     File.read("/proc/cmdline").split(/\\s+/).grep(/^androidboot.slot_suffix=/).first.split("=").last
Dec 28 11:44:19 nixos boot-control-start[92386]:                                                                                    ^^^^^^
Dec 28 11:44:19 nixos boot-control-start[92386]:         from /nix/store/jww9749gsrfwj1xw26g878flr74lwwpl-boot-control-2022-10-18/bin/boot-control:177:in `part'
Dec 28 11:44:19 nixos boot-control-start[92386]:         from /nix/store/jww9749gsrfwj1xw26g878flr74lwwpl-boot-control-2022-10-18/bin/boot-control:181:in `private_bits'
Dec 28 11:44:19 nixos boot-control-start[92386]:         from /nix/store/jww9749gsrfwj1xw26g878flr74lwwpl-boot-control-2022-10-18/bin/boot-control:201:in `tries_remaining'
Dec 28 11:44:19 nixos boot-control-start[92386]:         from /nix/store/jww9749gsrfwj1xw26g878flr74lwwpl-boot-control-2022-10-18/bin/boot-control:211:in `report'
Dec 28 11:44:19 nixos boot-control-start[92386]:         from /nix/store/jww9749gsrfwj1xw26g878flr74lwwpl-boot-control-2022-10-18/bin/boot-control:218:in `<main>'
Dec 28 11:44:19 nixos systemd[1]: boot-control.service: Main process exited, code=exited, status=1/FAILURE
Dec 28 11:44:19 nixos systemd[1]: boot-control.service: Failed with result 'exit-code'.
Dec 28 11:44:19 nixos systemd[1]: Failed to start Mark boot as successful.
warning: error(s) occurred while switching to the new configuration
```

Despite the other PR saying sound is working, I never really heard it on my device. However I saw how the bars moved in pavucontrol so maybe it is working but not loud enough. (I recall having a problem in pmOS where it was pretty silent until I messed with alsa).
What I also noticed is that unlocking SIM doesn't seem to work ootb.

plasma seems to be the more stable experience. phosh and gnome-mobile work not so great. (Years ago on pmOS phosh was better than plasma and plasma was the interface where most apps crashed, heh).


So yeah and for lurkers wanting to get this on their beryllium and since the documentation on mobile.nixos.org is a bit confusing: https://gist.github.com/schrmh/01c0271bed160033489d7389f1101025