### PR TITLE
fix bugs in moto-potter install docs 

### DIFF
--- a/devices/motorola-potter/README.adoc
+++ b/devices/motorola-potter/README.adoc
@@ -3,61 +3,6 @@ include::_support/common.inc[]
 
 == Device-specific notes
 
-=== Hardware Revisions
-
-This device has been through several hardware revisions: the kernel
-describes `P0A`, `P1A`, `P1B`, `P2A`, `P2A2`, `P2B`, and `P3A` but
-that's not an exhaustive list.  Each of these revisions corresponds to
-a separate hardware configuration description (device tree) in the
-vendor kernel, but on examination it turns out that several are
-identical to each other.
-
-According to the commit messages, the two hardware changes that required
-device tree changes were
-
-* (U) "Change usbid-gpio from 66 to 59" (git sha 305e2610c598dc4e)
-* (D) "boost clock use pdm clock instead" (git sha c42744ebf80da79a0)
-
-[width="50%",options="header"]
-|==========================
-|hwrev | board-id | (mis)features
-
-|P0A  | <0x44 0x80a0> |  U D
-|P1A  | <0x44 0x81a0> |  U D
-|P1B  | <0x44 0x81b0> |  D
-|P2A  | <0x44 0x82a0> |  D
-|     | <0x45 0x82a0> |  D
-|P2A2 | <0x45 0x82a2> | 
-|P2B  | <0x45 0x82b0> |
-|P3A  | <0x46 0x83a0> |
-|P3B  | <0x46 0x83b0> |
-|==========================
-
-
-Thus we can describe the complete range of hardware using only three
-variations instead of seven, which represents a significant space
-saving on the boot partition
-
-- msm8953-potter-p0a-p1a.dtb   (contains U and D fixes)
-- msm8953-potter-p1b-p2a.dtb   (contains D fix only)
-- msm8953-potter-p2a2-plus.dtb (contains no fix)
-
-
-==== What about `P3B`?
-
-The vendor kernel does not include a device tree source with
-appropriate board-id for hwrev `P3B`, but empirically (by consulting
-`/proc/device-tree/board-id` on a device running Android) it looks like
-the bootloader chooses the `P3A` DTB instead. As far as I understand it
-this goes against the https://github.com/xiaolu/mkbootimg_tools/blob/master/dtbtool.txt[documented rules]
-for choosing a device tree - https://android.googlesource.com/kernel/msm.git/+/android-msm-bullhead-3.10-n-preview-1/Documentation/devicetree/bindings/arm/msm/board-id.txt?autodive=0%2F%2F%2F%2F[according to
-sources]
-the platform subtype is the lowest 8 bits of the second element of the
-`board-id`, and clearly `0xa0 != 0xb0`, but it seems to do it anyway.
-
-If you have a device with a hwrev *after* `P3B`, I'd love to hear from
-you about how it behaves in this regard.
-
 
 === Firmware for Wi-Fi
 

--- a/modules/system-types/android/device-notes.fastboot.adoc.erb
+++ b/modules/system-types/android/device-notes.fastboot.adoc.erb
@@ -19,12 +19,12 @@ Make backups.
 This will produce a folder with a flashing script, and the partition images for
 your _<%= info["fullName"] %>_.
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-fastboot-images
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-fastboot-images
 
 Alternatively, you can build a specific partition image:
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-bootimg
- $ nix-build --argstr device <%= info["identifier"] %> -A build.rootfs
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-bootimg
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.rootfs
 
 The device will need to be booted in its bootloader, or `fastboot`, mode.
 
@@ -45,9 +45,9 @@ An alternative installation method is to use a flashable zip. The flashable zip
 can be built for your _<%= info["fullName"] %>_ using one of the following
 commands:
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-flashable-bootimg
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-flashable-system
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-flashable-zip
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-flashable-bootimg
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-flashable-system
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-flashable-zip
 
 The first two will flash only a specific partition. The last one contains the
 partitions of the two previous one.

--- a/modules/system-types/android/device-notes.lk2nd.adoc.erb
+++ b/modules/system-types/android/device-notes.lk2nd.adoc.erb
@@ -29,7 +29,7 @@ Alternatively, you can build a specific partition image:
 
 
 The device requires the
-"[lk2nd](https://github.com/msm8953-mainline/lk2nd)" secondary
+link:https://github.com/msm8953-mainline/lk2nd[lk2nd] secondary
 bootloader to be installed in the `boot` partition. This runs after
 your existing bootloader and does some hardware setup required to
 allow mainline kernels to run on your device - as well as providing a
@@ -37,11 +37,11 @@ allow mainline kernels to run on your device - as well as providing a
 
 You can build lk2nd for your device as foilows:
 
-$ nix-build --argstr device <%= info["identifier"] %> -A pkgs.lk2ndMms8953
+ $ nix-build --argstr device <%= info["identifier"] %> -A pkgs.lk2ndMsm8953 -o lk2nd
 
 To install it, reboot into the bootloader (`fastboot` mode), then run
 
- $ fastboot flash boot result/lk2nd.img
+ $ fastboot flash boot lk2nd/lk2nd.img
 
 Now you can boot into lk2nd - press Volume Down while booting to enter
 Fastboot mode.  If your stock bootloader uses the same key

--- a/modules/system-types/android/device-notes.lk2nd.adoc.erb
+++ b/modules/system-types/android/device-notes.lk2nd.adoc.erb
@@ -8,7 +8,7 @@ and creating a filesytem for the boot image.
 ===
 These instructions depend on adb being enabled, so
 will not work with an "unconfigured" Mobile NixOS image.  If you have
-changed nothing else in your Mobile NixOS system the you will at
+changed nothing else in your Mobile NixOS system then you will at
 minimum need something like
 `{ lib, ... }: { mobile.adbd.enable = true; }` in the `local.nix` file.
 

--- a/modules/system-types/android/device-notes.lk2nd.adoc.erb
+++ b/modules/system-types/android/device-notes.lk2nd.adoc.erb
@@ -20,12 +20,12 @@ Make backups.
 This will produce a folder with the partition images for
 your _<%= info["fullName"] %>_.
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-fastboot-images
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-fastboot-images
 
 Alternatively, you can build a specific partition image:
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-bootimg
- $ nix-build --argstr device <%= info["identifier"] %> -A build.rootfs
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-bootimg
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.rootfs
 
 
 The device requires the

--- a/modules/system-types/android/device-notes.lk2nd.adoc.erb
+++ b/modules/system-types/android/device-notes.lk2nd.adoc.erb
@@ -4,6 +4,15 @@ There is one tested installation method for your _<%= info["fullName"] %>_.
 It relies on flashing one or more partitions on your device
 and creating a filesytem for the boot image.
 
+[NOTE]
+===
+These instructions depend on adb being enabled, so
+will not work with an "unconfigured" Mobile NixOS image.  If you have
+changed nothing else in your Mobile NixOS system the you will at
+minimum need something like
+`{ lib, ... }: { mobile.adbd.enable = true; }` in the `local.nix` file.
+
+
 [WARNING]
 ====
 *All installation methods can lead to data loss.*
@@ -35,7 +44,7 @@ your existing bootloader and does some hardware setup required to
 allow mainline kernels to run on your device - as well as providing a
 "fastboot" interface for devices that don't already have one.
 
-You can build lk2nd for your device as foilows:
+You can build lk2nd for your device as follows:
 
  $ nix-build --argstr device <%= info["identifier"] %> -A pkgs.pkgsBuild.lk2ndMsm8953 -o lk2nd
 

--- a/modules/system-types/android/device-notes.lk2nd.adoc.erb
+++ b/modules/system-types/android/device-notes.lk2nd.adoc.erb
@@ -37,7 +37,7 @@ allow mainline kernels to run on your device - as well as providing a
 
 You can build lk2nd for your device as foilows:
 
- $ nix-build --argstr device <%= info["identifier"] %> -A pkgs.lk2ndMsm8953 -o lk2nd
+ $ nix-build --argstr device <%= info["identifier"] %> -A pkgs.pkgsBuild.lk2ndMsm8953 -o lk2nd
 
 To install it, reboot into the bootloader (`fastboot` mode), then run
 

--- a/modules/system-types/android/device-notes.odin.adoc.erb
+++ b/modules/system-types/android/device-notes.odin.adoc.erb
@@ -19,12 +19,12 @@ Make backups.
 This will produce a folder with a flashing script, and the partition images for
 your _<%= info["fullName"] %>_.
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-fastboot-images
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-fastboot-images
 
 Alternatively, you can build a specific partition image:
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-bootimg
- $ nix-build --argstr device <%= info["identifier"] %> -A build.rootfs
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-bootimg
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.rootfs
 
 The device will need to be booted in its bootloader, or *odin*, mode.
 
@@ -45,9 +45,9 @@ An alternative installation method is to use a flashable zip. The flashable zip
 can be built for your _<%= info["fullName"] %>_ using one of the following
 commands:
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-flashable-bootimg
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-flashable-system
- $ nix-build --argstr device <%= info["identifier"] %> -A build.android-flashable-zip
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-flashable-bootimg
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-flashable-system
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.android-flashable-zip
 
 The first two will flash only a specific partition. The last one contains the
 partitions of the two previous one.

--- a/overlay/lk2nd/msm8953.nix
+++ b/overlay/lk2nd/msm8953.nix
@@ -51,6 +51,10 @@ in stdenv.mkDerivation {
     cp ./build-msm8953-secondary/lk2nd.img $out
   '';
 
-  makeFlags = [ "msm8953-secondary" "TOOLCHAIN_PREFIX=arm-none-eabi-" ];
+  makeFlags = [
+    "msm8953-secondary"
+    "LD=arm-none-eabi-ld"
+    "TOOLCHAIN_PREFIX=arm-none-eabi-"
+  ];
 
 }


### PR DESCRIPTION
Address a number of niggles I found when trying to follow my own instructions for the Motorola G5 Plus. With these changes I can boot my device as far as the `login` prompt (haven't tested anything more complicated)

(1) substitute "outputs" for "build" as it gives a warning when you run it

```
$ nix-build --argstr device motorola-potter -A build.android-fastboot-images trace: (Using pinned Nixpkgs at 684c17c429c42515bafb3ad775d2a710947f3d67) trace: **************************************
trace: * Evaluating device: motorola-potter *
trace: **************************************
trace: The `build` argument has been renamed `outputs`. This alias will be removed after 2022-05. trace: Building with crossSystem?: aarch64-linux != x86_64-linux → we are.
       crossSystem: config: aarch64-unknown-linux-gnu
       
```

(2) make lk2nd build

(3) remove obsolete stuff about hardware revisions that was relevant only to vendor kernel

(4) it requires adb, so tell people that adb is required.

