### PR TITLE
boot/init: fix showing system.nixos.label in the boot menu

### DIFF
--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -50,13 +50,14 @@ class Tasks::SwitchRoot < SingletonTask
       if path == base then
         {
           id: "$default",
-          name: "Mobile NixOS - Default",
+          name: "Default",
         }
       else
         date = File.lstat(path).mtime.strftime("%F")
-        version_file = File.join(path, "nixos-version")
+        generation = path.delete_prefix(SYSTEM_MOUNT_POINT)
+        version_file = generation_file("nixos-version", generation: generation, missing_allowed: true)
         version =
-          if File.exist?(version_file)
+          unless version_file.nil?
             File.read(version_file)
           else
             nil
@@ -67,7 +68,7 @@ class Tasks::SwitchRoot < SingletonTask
           version,
         ].compact.join(" - ")
 
-        name = "Mobile NixOS ##{num} (#{details})"
+        name = "##{num} (#{details})"
 
         # This is the path we want to switch_root into.
         path = File.readlink(path)
@@ -258,11 +259,11 @@ class Tasks::SwitchRoot < SingletonTask
       .all?
   end
 
-  def generation_file(name, missing_allowed: false)
+  def generation_file(name, generation: selected_generation, missing_allowed: false)
     begin
       # First, resolve any links pointing to the generation dir itself.
       # Otherwise we'll try to resolve a path that may not exist.
-      resolved_generation = readlink_system(selected_generation)
+      resolved_generation = readlink_system(generation)
 
       full_path = File.join(resolved_generation, name)
 

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -27,7 +27,7 @@ class Tasks::SwitchRoot < SingletonTask
         filename = File.readlink(File.join(SYSTEM_MOUNT_POINT, prev_filename))
 
         # Relative link? Make absolute.
-        unless filename.match(%r{^/})
+        unless filename.start_with?("/")
           filename = File.join(File.dirname(prev_filename), filename)
         end
       end
@@ -267,7 +267,7 @@ class Tasks::SwitchRoot < SingletonTask
       full_path = File.join(resolved_generation, name)
 
       # Then resolve links to the actual artifact of the generation.
-      artifact = readlink_system(File.join(resolved_generation, name))
+      artifact = readlink_system(full_path)
       # Finally, return joined to the mount point.
       File.join(SYSTEM_MOUNT_POINT, artifact)
     rescue => e


### PR DESCRIPTION
This implements what you suggested in https://github.com/NixOS/mobile-nixos/issues/595#issuecomment-1468728236.

These are the first lines of Ruby I have ever written, so please suggest any improvements you can think of.

I removed the "Mobile NixOS" strings from every button as it doesn't fit on the screen of my PinePhone otherwise.

I'm not yet happy with the implementation:
- My implementation relies on `#generation_file` returning `nil` if the file does not exist. But if I change `nixos-version` to `nixos-version-bla` for testing, it does not seem to do so. Under which circumstances does `#generation_file` return `nil`?
- It's a bit ugly how I have to use `delete_prefix()` to remove `/mnt` from the start of the string. Otherwise `readlink_system` does not resolve the symlink. Do you have any better ideas?
- Is there a way to reduce the code duplication in `generation: generation`? Kind of like `inherit generation` in Nix?
- Is there a way to make the code which sets `version` more concise?
- Is it possible to truncate the label on the button, so the buttons always fit on the screen without scrolling horizontally?

Closes #595.