### PR TITLE
Disable warning about not having a bootloader

### DIFF
--- a/modules/bootloader.nix
+++ b/modules/bootloader.nix
@@ -26,6 +26,9 @@ in
   config = mkIf (config.mobile.bootloader.enable) {
     boot.loader.grub.enable = false;
     boot.loader.generic-extlinux-compatible.enable = false;
+
+    # Shut up warning about not having a boot loader.
+    system.build.installBootLoader = lib.mkDefault "${pkgs.coreutils}/bin/true";
   };
 }
 


### PR DESCRIPTION
Without this change, rebuilding the system would always print the following warning:
```
Warning: do not know how to make this configuration bootable; please enable a boot loader.
```
This is a useless warning when mobile-nixos is used as a "bootloader" and may confuse/scare new users.


Please check if this is the correct place to put this code and not for example in the implementation of `mobile.boot.stage-1.enable` or something.