### PR TITLE
Add fluffychat-software-rendering

### DIFF
--- a/overlay/fluffychat-software-rendering/default.nix
+++ b/overlay/fluffychat-software-rendering/default.nix
@@ -1,0 +1,15 @@
+{ symlinkJoin
+, fluffychat
+, makeWrapper
+}:
+
+symlinkJoin {
+  name = "fluffychat";
+  paths = [ fluffychat ];
+  nativeBuildInputs = [ makeWrapper ];
+  postBuild = ''
+    wrapProgram $out/bin/fluffychat \
+      --set LIBGL_ALWAYS_SOFTWARE 1
+  '';
+}
+

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -20,6 +20,7 @@ in
     dtbTool = callPackage ./dtbtool { };
     dtbTool-exynos = callPackage ./dtbtool-exynos { };
     eg25-manager = callPackage ./eg25-manager { };
+    fluffychat-software-rendering = callPackage ./fluffychat-software-rendering { };
     libhybris = callPackage ./libhybris {
       # FIXME : verify how it acts on native aarch64 build.
       stdenv = if self.buildPlatform != self.targetPlatform then


### PR DESCRIPTION
The normal FluffyChat only shows a white screen on the PinePhone, probably due to missing OpenGL features.
This wrapper package allows FluffyChat to work fairly well on the PinePhone.