### PR TITLE
installer: Use systemd-repart for resizing the rootfs

### DIFF
--- a/examples/installer/modules/filesystems.nix
+++ b/examples/installer/modules/filesystems.nix
@@ -24,22 +24,6 @@ in
 
   # It's acceptable here to lose some boot time to resizing the partition all the time.
   # Logic is the same as SD card enlargement.
-  boot.postBootCommands = ''
-    (
-      set -euo pipefail
-      PS4=" $ "
-      set -x
-
-      # Figure out device names for the boot device and root filesystem.
-      rootPart=$(${pkgs.util-linux}/bin/findmnt -n -o SOURCE /)
-      bootDevice=$(lsblk -npo PKNAME $rootPart)
-      partNum=$(lsblk -npo MAJ:MIN $rootPart | ${pkgs.gawk}/bin/awk -F: '{print $2}')
-
-      # Resize the root partition and the filesystem to fit the disk
-      echo ",+," | sfdisk -N$partNum --no-reread $bootDevice
-      ${pkgs.parted}/bin/partprobe
-      ${pkgs.e2fsprogs}/bin/resize2fs $rootPart
-    )
-  '';
+  boot.initrd.systemd.repart.enable = true;
 
 }


### PR DESCRIPTION
Use systemd-repart instead of potentially more brittle shell logic.

Fixes #654
