### PR TITLE
boot/init: Refactor SwitchRoot and fix labels

### DIFF
--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -49,7 +49,7 @@ class Tasks::SwitchRoot < SingletonTask
       if path == base then
         {
           id: "$default",
-          name: "Mobile NixOS - Default",
+          name: "NixOS - Default",
         }
       else
         date = File.lstat(path).mtime.strftime("%F")
@@ -66,7 +66,7 @@ class Tasks::SwitchRoot < SingletonTask
           version,
         ].compact.join(" - ")
 
-        name = "Mobile NixOS ##{num} (#{details})"
+        name = "NixOS ##{num} (#{details})"
 
         # This is the path we want to switch_root into.
         path = File.readlink(path)

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -8,7 +8,6 @@ class Tasks::SwitchRoot < SingletonTask
   def initialize()
     add_dependency(:Task, Tasks::Splash.instance)
     add_dependency(:Target, :SwitchRoot)
-    @target = SYSTEM_MOUNT_POINT
 
     # By default, with stage-0, we prefer using the generation kernel
     # This may be overriden by the user recovery user interface
@@ -110,13 +109,13 @@ class Tasks::SwitchRoot < SingletonTask
     end
 
     # The default generation
-    if File.symlink?(File.join(@target, DEFAULT_SYSTEM_LINK))
+    if File.symlink?(File.join(SYSTEM_MOUNT_POINT, DEFAULT_SYSTEM_LINK))
       $logger.info("Using '#{DEFAULT_SYSTEM_LINK}' default generation...")
       return DEFAULT_SYSTEM_LINK
     end
 
     # Otherwise, we need to re-hydrate a system!
-    registration = File.join(@target, "nix-path-registration")
+    registration = File.join(SYSTEM_MOUNT_POINT, "nix-path-registration")
     if File.exist?(registration)
       $logger.info("Getting NixOS generation from nix-path-registration...")
       path = File.read(registration)
@@ -340,12 +339,12 @@ class Tasks::SwitchRoot < SingletonTask
       "/dev",
       "/run",
     ].each do |mount_point|
-      new_location = File.join(@target, mount_point)
+      new_location = File.join(SYSTEM_MOUNT_POINT, mount_point)
       FileUtils.mkdir_p(new_location)
       System.run("mount", "--move", mount_point, new_location)
     end
 
     switch_root = System.which("switch_root")
-    System.exec({}, switch_root, @target, init)
+    System.exec({}, switch_root, SYSTEM_MOUNT_POINT, init)
   end
 end

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -14,16 +14,15 @@ class Tasks::SwitchRoot < SingletonTask
     @use_generation_kernel = STAGE == 0
   end
 
-  # Given a path name, without the leading SYSTEM_MOUNT_POINT, resolves
-  # symlinks to get the real name of the file.
-  # The returned path is not prefixed with SYSTEM_MOUNT_POINT either.
-  def readlink_system(filename)
+  # Resolves symlinks under a given root to get the real name of the file.
+  # The returned path is not prefixed with given root either.
+  def readlink_rooted(root, filename)
     # Resolve the full pathname
     loop do
       prev_filename = filename
 
-      if File.symlink?(File.join(SYSTEM_MOUNT_POINT, prev_filename))
-        filename = File.readlink(File.join(SYSTEM_MOUNT_POINT, prev_filename))
+      if File.symlink?(File.join(root, prev_filename))
+        filename = File.readlink(File.join(root, prev_filename))
 
         # Relative link? Make absolute.
         unless filename.match(%r{^/})
@@ -34,6 +33,10 @@ class Tasks::SwitchRoot < SingletonTask
     end
 
     filename
+  end
+
+  def readlink_system(filename)
+    readlink_rooted(SYSTEM_MOUNT_POINT, filename)
   end
 
   # Creates the generation selection list.


### PR DESCRIPTION
Closes #595.
Closes #679.

* * *

This is not the final solution to the whole problem about showing stuff, but this is at least fixing this issue and making the `SwitchRoot` implementation easier to grok.

The main issue this fixes in the implementation is making sense of *where files are* and *how paths are handled*.

The main challenge is that some paths need to be resolved in the `/mnt` mount point, but as-if if was the actual rootfs. Some don't.

So now, when dealing with paths, there are two discrete functions *on an instance of `Generation`* that can be used.

* * *

In addition, move the code implementing stage-0 bits in their own module, such that it is obvious what it does, compared to the rest. It will be removed later down the line.

* * *

An actual solution to showing generation information will be to rethink the widget in the recovery menu, such that it shows each generation with a set of widgets, and a button to boot it.

When working on that in the future, designing with specialisations in mind would be wise.

* * *

When testing, I used this to test with stage-0 in the test VM

```diff
diff --git a/examples/hello/configuration.nix b/examples/hello/configuration.nix
index d16fd23c..0955f6dc 100644
--- a/examples/hello/configuration.nix
+++ b/examples/hello/configuration.nix
@@ -133,7 +133,7 @@ in
   # Override stage-0 support for this example app.
   # It's only noise, and the current stage-0 is not able to boot anything else
   # than a system it was built for anyway.
-  mobile.quirks.supportsStage-0 = lib.mkForce false;
+  ##mobile.quirks.supportsStage-0 = lib.mkForce false;
 
   # Skip a long-running build for the documentation HTML.
   documentation.enable = false;

```

```
 $ nix-build ./examples/hello/ --arg device ./devices/uefi-x86_64 -A outputs.vm && ./result
```