### PR TITLE
lvgui: 2023-05-01 -> 2024-03-09

### DIFF
--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -95,13 +95,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2023-05-01";
+    version = "2024-03-09";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "e1a23580905419b598b7ed673e47bf210c502bb4";
-      sha256 = "sha256-VbvUVWifvkjQRyqXfNgIFc3LKpFfh7D1xGbJ02cZYpk=";
+      rev = "7e77f26e92c7dcebd582f9fd41b3647292b739a1";
+      hash = "sha256-0Fb3Wisw9hKXwFUACsFqvuiiO7i79/RxsT10kRGpdRw=";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.


### PR DESCRIPTION
Fixes the underlying issue in #690.

See https://github.com/mobile-nixos/lvgui/pull/18

* * *

### What was done

 - Checked with `examples/hello` that the UEFI VM test still works.
 - Forced wrong card path to see the failure behaviour, still falls back to fbdev.

### TODO still

 - ~~Reproduce issue on device (acer-juniper, verify fallback to fbdev with `examples/hello`)~~ testing sufficient
 - ~~Validate fix on device (acer-juniper, verify usage of drm with `examples/hello`)~~ testing sufficient
 - Merge fix in `lvgui` then update this PR to point at the right repo.


cc @benaryorg, if you want to test and validate.