### PR TITLE
families/mainline-chromeos: Enable cr50 tpm support declaratively

### DIFF
--- a/devices/families/mainline-chromeos/default.nix
+++ b/devices/families/mainline-chromeos/default.nix
@@ -25,10 +25,10 @@
       CHARGER_SBS = module;
       MANAGER_SBS = module;
 
-      TCG_TIS_CORE        = module;
-      TCG_TIS_SPI         = module;
-      TCG_TIS_SPI_CR50    = yes;
-      TCG_TIS_I2C_CR50    = yes;
+      TCG_TIS_CORE = module;
+      TCG_TIS_SPI = module;
+      TCG_TIS_SPI_CR50 = yes;
+      TCG_TIS_I2C_CR50 = yes;
     })
   ];
 }

--- a/devices/families/mainline-chromeos/default.nix
+++ b/devices/families/mainline-chromeos/default.nix
@@ -9,11 +9,6 @@
       "sbs-battery"
       "sbs-charger"
       "sbs-manager"
-
-      "tpm"
-      "tpm_tis_core"
-      "tpm_tis_spi"
-      "tcg_tis_i2c_cr50"
     ];
   };
 
@@ -27,11 +22,11 @@
       CHARGER_SBS = module;
       MANAGER_SBS = module;
 
-      TCG_TPM = module;
-      TCG_TIS_CORE = module;
-      TCG_TIS_SPI = module;
+      # CR50 TPM support
+      TCG_TIS_CORE = yes;
+      TCG_TIS_SPI = yes;
       TCG_TIS_SPI_CR50 = yes;
-      TCG_TIS_I2C_CR50 = module;
+      TCG_TIS_I2C_CR50 = yes;
     })
   ];
 }

--- a/devices/families/mainline-chromeos/default.nix
+++ b/devices/families/mainline-chromeos/default.nix
@@ -9,6 +9,11 @@
       "sbs-battery"
       "sbs-charger"
       "sbs-manager"
+
+      "tpm"
+      "tpm_tis_core"
+      "tpm_tis_spi"
+      "tcg_tis_i2c_cr50"
     ];
   };
 
@@ -21,6 +26,12 @@
       BATTERY_SBS = module;
       CHARGER_SBS = module;
       MANAGER_SBS = module;
+
+      TCG_TPM = module;
+      TCG_TIS_CORE = module;
+      TCG_TIS_SPI = module;
+      TCG_TIS_SPI_CR50 = yes;
+      TCG_TIS_I2C_CR50 = module;
     })
   ];
 }

--- a/devices/families/mainline-chromeos/default.nix
+++ b/devices/families/mainline-chromeos/default.nix
@@ -9,6 +9,9 @@
       "sbs-battery"
       "sbs-charger"
       "sbs-manager"
+
+      "tpm_tis_core"
+      "tpm_tis_spi"
     ];
   };
 
@@ -22,11 +25,10 @@
       CHARGER_SBS = module;
       MANAGER_SBS = module;
 
-      # CR50 TPM support
-      TCG_TIS_CORE = yes;
-      TCG_TIS_SPI = yes;
-      TCG_TIS_SPI_CR50 = yes;
-      TCG_TIS_I2C_CR50 = yes;
+      TCG_TIS_CORE        = module;
+      TCG_TIS_SPI         = module;
+      TCG_TIS_SPI_CR50    = yes;
+      TCG_TIS_I2C_CR50    = yes;
     })
   ];
 }

--- a/devices/families/mainline-chromeos/default.nix
+++ b/devices/families/mainline-chromeos/default.nix
@@ -3,15 +3,17 @@
 {
   mobile.boot.stage-1 = {
     kernel.modular = true;
+    kernel.modules = [ 
+      "tpm_tis_core"
+      "tpm_tis_spi"
+      "tpm_tis_i2c_cr50"
+    ];
     kernel.additionalModules = [
       # Breaks udev if builtin or loaded before udev runs.
       # Using `additionalModules` means udev will load them as needed.
       "sbs-battery"
       "sbs-charger"
-      "sbs-manager"
-
-      "tpm_tis_core"
-      "tpm_tis_spi"
+      "sbs-manager"      
     ];
   };
 
@@ -28,7 +30,7 @@
       TCG_TIS_CORE = module;
       TCG_TIS_SPI = module;
       TCG_TIS_SPI_CR50 = yes;
-      TCG_TIS_I2C_CR50 = yes;
+      TCG_TIS_I2C_CR50 = module;
     })
   ];
 }


### PR DESCRIPTION
Attempt to address #696, as a follow up of #678.

This PR attempts to change config of `families/mainline-chromeos`, building TPM CR50 support as kernel module and load them in stage-1 kernel.