### PR TITLE
splash: Add BGRT support

### DIFF
--- a/boot/lib/lvgui/lvgl/hacks.rb
+++ b/boot/lib/lvgui/lvgl/hacks.rb
@@ -21,6 +21,7 @@ module LVGL::Hacks
     LVGL::Hacks.set_assets_path(data_dir)
 
     LVGUI::Native.hal_init(get_asset_path(""))
+    LVGUI::Native.lv_bmp_init()
     LVGUI::Native.lv_nanosvg_init()
   end
 

--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -95,13 +95,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2024-03-09";
+    version = "2024-03-25";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "7e77f26e92c7dcebd582f9fd41b3647292b739a1";
-      hash = "sha256-0Fb3Wisw9hKXwFUACsFqvuiiO7i79/RxsT10kRGpdRw=";
+      rev = "4dfc178445c5595ae89ef2697d4b8dfea14b2316";
+      hash = "sha256-8wcitxfLZIedjb509zpRxuYO6o9qIatXO93NGxMhgUs=";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/boot/script-loader/mruby-lvgui-native/src/gem.c
+++ b/boot/script-loader/mruby-lvgui-native/src/gem.c
@@ -15,6 +15,7 @@
 #include <lv_drv_conf.h>
 #include <lv_conf.h>
 #include <lvgl/lvgl.h>
+#include <lv_lib_bmp/lv_bmp.h>
 #include <lv_lib_nanosvg/lv_nanosvg.h>
 #include <font.h>
 #include <hal.h>
@@ -4878,6 +4879,27 @@ mrb_mruby_lvgui_native_hal_init(mrb_state *mrb, mrb_value self)
   
     // Calling native function
     hal_init(param_unnamed_parameter_0);
+  
+    // Converts return value back to a valid mruby value
+    return mrb_nil_value();
+}
+
+//
+////////
+
+////////
+// Bindings for: `void lv_bmp_init()`
+
+static mrb_value
+mrb_mruby_lvgui_native_lv_bmp_init(mrb_state *mrb, mrb_value self)
+{
+    /* No return value */
+  
+  
+  
+  
+    // Calling native function
+    lv_bmp_init();
   
     // Converts return value back to a valid mruby value
     return mrb_nil_value();
@@ -13585,6 +13607,22 @@ mrb_mruby_lvgui_native_gem_init(mrb_state* mrb)
     mLVGUI__Native__References,
     mrb_symbol_value(mrb_intern_lit(mrb, "hal_init")),
     mrb_mruby_lvgui_native_wrap_pointer(mrb, (void *) hal_init)
+  );
+
+  // ```void lv_bmp_init();```
+  mrb_define_module_function(
+    mrb,
+    mLVGUI__Native,
+    "lv_bmp_init",
+    mrb_mruby_lvgui_native_lv_bmp_init,
+    MRB_ARGS_REQ(0)
+  );
+  
+  mrb_hash_set(
+    mrb,
+    mLVGUI__Native__References,
+    mrb_symbol_value(mrb_intern_lit(mrb, "lv_bmp_init")),
+    mrb_mruby_lvgui_native_wrap_pointer(mrb, (void *) lv_bmp_init)
   );
 
   // ```void lv_nanosvg_init();```

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -104,17 +104,20 @@ class UI
     # as per the spec, but in practice many have centered BGRTs.
     # So we try to guesstimate a centered BGRT here.
     midpoint = @screen.get_height/2
+    bottom_third = @screen.get_height() / 3.0 * 2
     logo_bottom = @logo.get_height() + @logo.get_y()
     @vertical_offset = logo_bottom - midpoint + 5*@unit
     @vertical_offset = 0 if @vertical_offset < 0
 
-    # TODO: support "big" or "fullscreen" BGRTs
-    #       -> when they dip into the 1/3rd area?
     # Some vendors ship a full-screen BGRT.
     # Since we can't do much about it, we're assuming this:
     #   - Has a centered logo
     #   - The bottom third of the display is free
     # This assumption should hold since this is the assumptions for Windows.
+    if (@vertical_offset + midpoint) > bottom_third
+      # Force the UI area to be at the last third at the bottom.
+      @vertical_offset = bottom_third - midpoint + 5*@unit
+    end
   end
 
   def add_progress_bar()

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -33,6 +33,10 @@ class UI
     File.exist?(BGRT_PATH)
   end
 
+  def use_bgrt?()
+    has_bgrt?() && Configuration["splash"]["useBGRT"]
+  end
+
   def initialize()
     @vertical_offset = 0
 
@@ -67,9 +71,9 @@ class UI
   end
 
   def add_logo()
-    if has_bgrt?()
+    if use_bgrt?()
       # Work around the extension sniffing from the image decoders...
-      File.symlink(BGRT_PATH, "/bgrt.bmp")
+      File.symlink(BGRT_PATH, "/bgrt.bmp") unless File.exist?("/bgrt.bmp")
       file = "/bgrt.bmp"
     else
       file = LVGL::Hacks.get_asset_path("logo.svg")
@@ -87,7 +91,7 @@ class UI
     @logo.set_src(file)
 
     # Position the logo
-    if has_bgrt?
+    if use_bgrt?
       x = File.read("/sys/firmware/acpi/bgrt/xoffset").to_i
       y = File.read("/sys/firmware/acpi/bgrt/yoffset").to_i
       @logo.set_pos(x, y)
@@ -198,6 +202,8 @@ class UI
   # Its presence will be whatever state the cover is in.
   def add_cover_bgrt()
     return unless has_bgrt?()
+    # Work around the extension sniffing from the image decoders...
+    File.symlink(BGRT_PATH, "/bgrt.bmp") unless File.exist?("/bgrt.bmp")
     file = "/bgrt.bmp"
 
     @cover_bgrt = LVGL::LVImage.new(@cover)

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -11,6 +11,8 @@ module Kernel
 end
 
 class UI
+  BGRT_PATH = "/sys/firmware/acpi/bgrt/image"
+
   FG_COLOR = Configuration["splash"] && Configuration["splash"]["foreground"]
   FG_COLOR = FG_COLOR.to_i(16) if FG_COLOR.is_a?(String)
   FG_COLOR ||= 0xFFFFFFFF
@@ -27,7 +29,13 @@ class UI
   # As this is not using BaseWindow, LVGUI::init isn't handled for us.
   LVGUI.init(theme: THEME.to_sym, assets_path: "boot-splash/assets")
 
+  def has_bgrt?()
+    File.exist?(BGRT_PATH)
+  end
+
   def initialize()
+    @vertical_offset = 0
+
     add_screen
     add_page
     # Biggest of horizontal or vertical; a percent.
@@ -40,7 +48,8 @@ class UI
     add_textarea
     add_keyboard
 
-    add_cover # last
+    add_cover
+    add_cover_bgrt
   end
 
   def add_label()
@@ -58,21 +67,50 @@ class UI
   end
 
   def add_logo()
-    file = LVGL::Hacks.get_asset_path("logo.svg")
-
-    if @page.get_height > @page.get_width
-      # 80% of the width
-      file = "#{file}?width=#{(@page.get_width * 0.8).to_i}"
+    if has_bgrt?()
+      # Work around the extension sniffing from the image decoders...
+      File.symlink(BGRT_PATH, "/bgrt.bmp")
+      file = "/bgrt.bmp"
     else
-      # 15% of the height
-      file = "#{file}?height=#{(@page.get_height * 0.15).to_i}"
+      file = LVGL::Hacks.get_asset_path("logo.svg")
+
+      if @page.get_height > @page.get_width
+        # 80% of the width
+        file = "#{file}?width=#{(@page.get_width * 0.8).to_i}"
+      else
+        # 15% of the height
+        file = "#{file}?height=#{(@page.get_height * 0.15).to_i}"
+      end
     end
 
     @logo = LVGL::LVImage.new(@page)
     @logo.set_src(file)
 
     # Position the logo
-    @logo.set_pos(*center(@logo, 0, -@logo.get_height))
+    if has_bgrt?
+      x = File.read("/sys/firmware/acpi/bgrt/xoffset").to_i
+      y = File.read("/sys/firmware/acpi/bgrt/yoffset").to_i
+      @logo.set_pos(x, y)
+    else
+      @logo.set_pos(*center(@logo, 0, -@logo.get_height))
+    end
+
+    # This is used to unify custom logo and BGRT sizes.
+    # The BGRT's center point **should** be at the one third mark of the screen,
+    # as per the spec, but in practice many have centered BGRTs.
+    # So we try to guesstimate a centered BGRT here.
+    midpoint = @screen.get_height/2
+    logo_bottom = @logo.get_height() + @logo.get_y()
+    @vertical_offset = logo_bottom - midpoint + 5*@unit
+    @vertical_offset = 0 if @vertical_offset < 0
+
+    # TODO: support "big" or "fullscreen" BGRTs
+    #       -> when they dip into the 1/3rd area?
+    # Some vendors ship a full-screen BGRT.
+    # Since we can't do much about it, we're assuming this:
+    #   - Has a centered logo
+    #   - The bottom third of the display is free
+    # This assumption should hold since this is the assumptions for Windows.
   end
 
   def add_progress_bar()
@@ -138,15 +176,15 @@ class UI
   # Used to handle fade-in/fade-out
   # This is because opacity handles multiple overlaid objects wrong.
   def add_cover()
-    @cover = LVGL::LVObject.new(@screen)
+    @cover = LVGL::LVContainer.new(@screen)
     # Make it so we can use the opacity to fade in/out
     @cover.set_opa_scale_enable(true)
     @cover.set_width(@screen.get_width())
     @cover.set_height(@screen.get_height())
     @cover.set_click(false)
 
-    @cover.get_style().dup.tap do |style|
-      @cover.set_style(style)
+    @cover.get_style(LVGL::CONT_STYLE::MAIN).dup.tap do |style|
+      @cover.set_style(LVGL::CONT_STYLE::MAIN, style)
 
       # Background for the splash
       style.body_main_color = BG_COLOR
@@ -154,6 +192,21 @@ class UI
       # Some themes will add a border to LVObject.
       style.body_border_width = 0
     end
+  end
+
+  # This is used to act as if we were fading "around" the BGRT.
+  # Its presence will be whatever state the cover is in.
+  def add_cover_bgrt()
+    return unless has_bgrt?()
+    file = "/bgrt.bmp"
+
+    @cover_bgrt = LVGL::LVImage.new(@cover)
+    @cover_bgrt.set_src(file)
+
+    # Position the logo
+    x = File.read("/sys/firmware/acpi/bgrt/xoffset").to_i
+    y = File.read("/sys/firmware/acpi/bgrt/yoffset").to_i
+    @cover_bgrt.set_pos(x, y)
   end
 
   def add_textarea()
@@ -303,7 +356,7 @@ class UI
   def center(el, x = 0, y = 0)
     [
       @screen.get_width  / 2 - el.get_width  / 2 + x,
-      @screen.get_height / 2 - el.get_height / 2 + y,
+      @screen.get_height / 2 - el.get_height / 2 + y + @vertical_offset,
     ]
   end
 end

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -122,6 +122,7 @@ in
             theme = mkDefault "night";
             background = mkDefault "0xFF000000";
             foreground = mkDefault "0xFFFFFFFF";
+            useBGRT    = mkDefault true;
           };
         }
       ];

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,6 +1,6 @@
 let
-  sha256 = "sha256:1gvi4vlq1cxyi3w2mqm939c5ib5509a2ycpwyki51jdgcpkh4x9c";
-  rev = "684c17c429c42515bafb3ad775d2a710947f3d67";
+  sha256 = "sha256:0xxbzvrr7kylvjn2yj0nnrm1qndx8rq99mlkk0ghvy364y5c5pv0";
+  rev = "44d0940ea560dee511026a53f0e2e2cde489b4d4";
 in
 builtins.trace "(Using pinned Nixpkgs at ${rev})"
 import (fetchTarball {


### PR DESCRIPTION
This adds support for using the BGRT instead of the Mobile NixOS logo in the Mobile NixOS stage-1.

This may be useful for stronger branding™ when re-using this stage-1 on some systems, like for example a Steam Deck.

![image](https://github.com/NixOS/mobile-nixos/assets/132835/dce21789-6ad7-4abf-a2f9-8fd0c772b16b)

As can be observed in this VM screenshot, the BGRT reacts accordingly. Its default position would be its normal position, so for the UEFI VM, with the progress bar, it is at its centered location.

### Things to do

[...]


### Things done

 - Tested in the UEFI VM.
 - Tested without a BGRT (kernel cmdline)
 - Add option to disable using the BGRT
     - (Using the kernel cmdline isn't a valid option here, we want to use the BGRT in the splash cover to transition nicely!!!)
 - Handle "large" BGRTs (e.g. starbook)
 - Merge https://github.com/mobile-nixos/lvgui/pull/19 and update commit
 - Test on hardware
    - With a "valid" BGRT (up top, not centered; GPD win mini)
    - With a centered BGRT (tp300la? chuwi? steamdeck?)
    - With a huge BGRT (HackBGRT it or check starbook?)