### PR TITLE
lvgui: Update with hotplug feature

### DIFF
--- a/boot/init/tasks/splash.rb
+++ b/boot/init/tasks/splash.rb
@@ -86,6 +86,8 @@ class Tasks::Splash < SingletonTask
     # Minimum amount of time spent waiting for devices, in seconds.
     wait_for_devices_delay = Configuration["quirks"]["wait_for_devices_delay"]
 
+    return unless wait_for_devices_delay > 0
+
     # Number of times this is looking at the state every second.
     # This is the "precision" at which it works, e.g. wait_for_devices_delay + (1.0/looks_per_second)
     # is the approximative minimum amount of time this will wait for.

--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -95,13 +95,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2024-03-25";
+    version = "2024-03-29";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "4dfc178445c5595ae89ef2697d4b8dfea14b2316";
-      hash = "sha256-8wcitxfLZIedjb509zpRxuYO6o9qIatXO93NGxMhgUs=";
+      rev = "8768bab377a7ccab0b25b96d204af670820f8c76";
+      hash = "sha256-lDmUppndyDGY1EJT7FC6Fdb3AT2M6D75FnXw4bPNrD0=";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -49,7 +49,7 @@ in
       };
       delay = mkOption {
         type = types.int;
-        default = 2;
+        default = 0;
         description = lib.mdDoc ''
           Minimum delay spent waiting for input devices to settle.
 


### PR DESCRIPTION
See: https://github.com/mobile-nixos/lvgui/pull/21

* * *

TLDR: we can drop a 2s wait for devices, and have any slow device show up eventually.

This is also helpful for the hello applet, and for the installer applet.

Note that this may make boot *feel* faster/better, as it will be able to show the splash as soon as graphics are ready, rather than wait for input.

* * *

### Things done

 - Tested (manually) with the UEFI VM. (first: check that HEAD^ won't see any input devices, then check that with HEAD they work again.)
 - Deploy on a few of my systems
 - Verify behaviour on multiple unplug/plug cycles (e.g. paths reuse?)
 - Merge https://github.com/mobile-nixos/lvgui/pull/21

