### PR TITLE
pine64-pine*: Update documentation to `outputs.disk-image`

### DIFF
--- a/devices/pine64-pinephone/README.adoc
+++ b/devices/pine64-pinephone/README.adoc
@@ -78,7 +78,7 @@ that the full disk image can be flashed to an SD card, and it will prioritise
 booting it.
 
 ```
- $ nix-build --argstr device pine64-pinephone -A build.disk-image
+ $ nix-build --argstr device pine64-pinephone -A outputs.disk-image
  $ dd if=result of=/dev/mmcblkX bs=8M oflag=sync,direct status=progress
 ```
 

--- a/devices/pine64-pinephonepro/README.adoc
+++ b/devices/pine64-pinephonepro/README.adoc
@@ -70,7 +70,7 @@ device. That block device can be the internal eMMC or the SD card.
 When using Tow-Boot, hold _volume down_ during boot to boot from the SD card.
 
 ```
- $ nix-build --argstr device pine64-pinephonepro -A build.disk-image
+ $ nix-build --argstr device pine64-pinephonepro -A outputs.disk-image
  $ dd if=result of=/dev/mmcblkX bs=8M oflag=sync,direct status=progress
 ```
 

--- a/devices/pine64-pinetab/README.adoc
+++ b/devices/pine64-pinetab/README.adoc
@@ -18,7 +18,7 @@ that the full disk image can be flashed to an SD card, and it will prioritise
 booting it.
 
 ```
- $ nix-build --argstr device pine64-pinetab -A build.disk-image
+ $ nix-build --argstr device pine64-pinetab -A outputs.disk-image
  $ dd if=result of=/dev/mmcblkX bs=8M oflag=sync,direct status=progress
 ```
 


### PR DESCRIPTION
```
trace: The `build` argument has been renamed `outputs`. This alias will be removed after 2022-05.
```