### PR TITLE
Fix impure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { device ? null
 , configuration ? null
-, pkgs ? (import ./pkgs.nix {})
+, system ? builtins.currentSystem
+, pkgs ? (import ./pkgs.nix { inherit system; })
 }@args':
 
 let

--- a/doc/_support/options/default.nix
+++ b/doc/_support/options/default.nix
@@ -28,6 +28,7 @@ let
   dummyEval = evalWith {
     device = (dummyConfig "aarch64-linux");
     modules = [];
+    inherit pkgs;
   };
 
   optionsJSON = (nixosOptionsDoc { options = dummyEval.options; }).optionsJSON;

--- a/lib/eval-with-configuration.nix
+++ b/lib/eval-with-configuration.nix
@@ -8,6 +8,7 @@
   # The identifier of the device this should be built for.
   # (This gets massaged later on)
 , device ? null
+, system ? if (pkgs == null) then builtins.currentSystem else pkgs.system
 , configuration
   # Internally used to tack on configuration by release.nix
 , additionalConfiguration ? {}
@@ -32,7 +33,7 @@ let
   eval = evalWith {
     device = final_device;
     modules = configuration;
-    inherit additionalConfiguration;
+    inherit additionalConfiguration pkgs system;
   };
 
   # Makes a mostly useless header.

--- a/lib/release-tools.nix
+++ b/lib/release-tools.nix
@@ -20,13 +20,15 @@ rec {
   evalWith =
     { modules
     , device
+    , pkgs
+    , system ? pkgs.system
     , additionalConfiguration ? {}
     , baseModules ? (
       (import ../modules/module-list.nix)
       ++ (import "${toString pkgs.path}/nixos/modules/module-list.nix")
     )
   }: evalConfig {
-    inherit baseModules;
+    inherit baseModules pkgs system;
     modules =
       (if device ? special
       then [ device.config ]
@@ -73,7 +75,8 @@ rec {
       # Eval with a configuration, for the given device.
       evalWithConfiguration = configuration: device: evalWith {
         modules = [ configuration ];
-        inherit device;
+        inherit device pkgs;
+        inherit (pkgs) system;
       };
 
       # The simplest eval for a device, with an empty configuration.

--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -24,7 +24,7 @@ in
         filteredArgs // {
         # Needed for hermetic eval, otherwise `eval-config.nix` will try
         # to use `builtins.currentSystem`.
-        inherit system;
+        inherit system pkgs;
         inherit baseModules;
         # Newer versions of module system pass specialArgs to modules, so try
         # to pass that to eval if possible.


### PR DESCRIPTION
Fixes Mobile NixOS's usage when Nix is in pure mode by taking some of the same attributes as NixOS itself does during system evaluation.