### PR TITLE
kernel-config: fix compressed firmware loading

### DIFF
--- a/support/kernel-config/nixos.nix
+++ b/support/kernel-config/nixos.nix
@@ -183,7 +183,8 @@ in
       BINFMT_SCRIPT = whenAtLeast "3.10" yes;
       BINFMT_MISC   = option yes;
       FW_LOADER_USER_HELPER_FALLBACK = option no;
-      FW_LOADER_COMPRESS = option yes;
+      FW_LOADER_COMPRESS = whenAtLeast "5.3" yes;
+      FW_LOADER_COMPRESS_ZSTD = whenAtLeast "5.19" yes;
       PREEMPT = no;
       PREEMPT_VOLUNTARY = yes;
       SCHED_SMT = yes;


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/302300 is merged, hardware.firmware are now compressed with zstd. On my oneplus-enchilada, this is causing the WLAN interface disappearing. This PR fixes that by copying the changes of kernel config from NixOS/nixpkgs#302300