### PR TITLE
lvgui: don't treat warnings as errors

### DIFF
--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -134,5 +134,6 @@ in
 
     enableParallelBuilding = true;
 
+    # https://github.com/mobile-nixos/lvgui/issues/23
     env.NIX_CFLAGS_COMPILE = "-Wno-error";
   }

--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -133,4 +133,6 @@ in
     ;
 
     enableParallelBuilding = true;
+
+    env.NIX_CFLAGS_COMPILE = "-Wno-error";
   }


### PR DESCRIPTION
Workaround the following build failure when building against the latest nixos-unstable

```
/build/source/lv_drivers/indev/libinput.c:109:6: warning: no previous prototype for 'libinput_set_file' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmissing-prototypes-Wmissing-prototypes8;;]
  109 | bool libinput_set_file(libinput_drv_instance* instance, char* dev_name)
      |      ^~~~~~~~~~~~~~~~~
/build/source/lv_drivers/indev/libinput.c:223:6: warning: no previous prototype for 'libinput_drv_init' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmissing-prototypes-Wmissing-prototypes8;;]
  223 | void libinput_drv_init(libinput_drv_add_cb_t callback)
      |      ^~~~~~~~~~~~~~~~~
/build/source/lv_drivers/indev/libinput.c: In function 'libinput_read':
/build/source/lv_drivers/indev/libinput.c:337:17: error: enumeration value 'LIBINPUT_EVENT_TABLET_PAD_DIAL' not handled in switch [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wswitch-enum-Wer>
  337 |                 switch (type) {
      |                 ^~~~~~
/build/source/lv_drivers/indev/libinput.c: At top level:
/build/source/lv_drivers/indev/libinput.c:532:31: warning: 'libinput_drv_instance_new' was used with no prototype before its definition [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmissing-p>
  532 | static libinput_drv_instance* libinput_drv_instance_new()
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/lv_drivers/indev/libinput.c:644:12: warning: 'xkbcommon_init' was used with no prototype before its definition [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmissing-prototypes-W>
  644 | static int xkbcommon_init() {
      |            ^~~~~~~~~~~~~~
CC /build/source/lv_drivers/indev/mousewheel.c
/build/source/lv_lib_freetype/lv_freetype.c:165:5: warning: no previous prototype for 'lv_freetype_init' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmissing-prototypes-Wmissing-prototypes8;>
  165 | int lv_freetype_init()
      |     ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:33: libinput.o] Error 1
make: *** Waiting for unfinished jobs....
```