### PR TITLE
Add Lenovo-kodama

### DIFF
--- a/devices/lenovo-kodama/README.adoc
+++ b/devices/lenovo-kodama/README.adoc
@@ -1,0 +1,19 @@
+= Lenovo Chromebook Tablet 10e
+include::_support/common.inc[]
+
+== Device-specific notes
+
+=== Developer mode
+
+For more details the link:https://chromium.googlesource.com/chromiumos/docs/+/master/debug_buttons.md#Firmware-Menu-Interface[
+Firmware Menu Interface] section from the upstream documentation can be read.
+
+You will need to:
+
+. Boot in _Recovery mode_ by powering on using `Power` + `Volume-Up` + `Volume-Down`
+. Activate Developer mode by pressing `Volume-Up` and `Volume-Down` simultaneously
+
+Note that this is only to allow you to boot unverified images.
+
+You may want to configure other options with GBB flags. This is left as an
+exercise to the reader.

--- a/devices/lenovo-kodama/default.nix
+++ b/devices/lenovo-kodama/default.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../families/mainline-chromeos-mt8183
+  ];
+
+  mobile.device.name = "lenovo-kodama";
+  mobile.device.identity = {
+    name = "Chromebook 10e";
+    manufacturer = "Lenovo";
+  };
+  mobile.device.supportLevel = "supported";
+  mobile.hardware = {
+    screen = {
+      # Panel is portrait CW compared to keyboard attachment.
+      width = 1200; height = 1920;
+    };
+  };
+
+  # Ensure orientation match with keyboard.
+  services.udev.extraHwdb = lib.mkBefore ''
+    sensor:modalias:platform:*
+      ACCEL_MOUNT_MATRIX=0, 1, 0; -1, 0, 0; 0, 0, -1 # Last I checked, this is wrong for this device
+  '';
+}


### PR DESCRIPTION
Lenovo-kodama (Chromebook tablet 10e) is the same hardware as Lenovo-krane.    
Verified this boots and is operable, with exception to screen rotation, which is a different offset then krane.