### PR TITLE
pine64-pinephone: kernel 6.9.7 -> 6.9.10

### DIFF
--- a/devices/pine64-pinephone/kernel/config.aarch64
+++ b/devices/pine64-pinephone/kernel/config.aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.9.7 Kernel Configuration
+# Linux/arm64 6.9.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-unknown-linux-gnu-gcc (GCC) 13.2.0"
 CONFIG_CC_IS_GCC=y

--- a/devices/pine64-pinephone/kernel/default.nix
+++ b/devices/pine64-pinephone/kernel/default.nix
@@ -6,14 +6,14 @@
 }:
 
 mobile-nixos.kernel-builder {
-  version = "6.9.7";
+  version = "6.9.10";
   configfile = ./config.aarch64;
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "megi";
     repo = "linux";
-    rev = "orange-pi-6.9-20240630-2043";
-    hash = "sha256-OoIBVxSNALklZz2/XbD+dI+C56noY8mumYqQBBrIQJo=";
+    rev = "orange-pi-6.9-20240721-2345";
+    hash = "sha256-WtLkMJnThYMLsZqbqTIhaTwQ0e2EE1Zq7DQX36L481o=";
   };
   patches = [
     ./0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch


### PR DESCRIPTION
This updates the PinePhone kernel to Linux 6.9.10.

I ran this kernel on my phone for a couple days and haven't noticed any regressions.