### PR TITLE
qrtr: update packages

### DIFF
--- a/overlay/qrtr/pd-mapper.nix
+++ b/overlay/qrtr/pd-mapper.nix
@@ -1,15 +1,15 @@
 { stdenv, lib, fetchFromGitHub, qrtr }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs:{
   pname = "pd-mapper";
-  version = "unstable-2022-02-08";
+  version = "1.0";
 
   buildInputs = [ qrtr ];
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "pd-mapper";
-    rev = "9d78fc0c6143c4d1b7198c57be72a6699ce764c4";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-vQZZ3WtZGh5OEw0EmlmT/My/cY6VRruuicsFR0YCQOw=";
   };
 
@@ -21,8 +21,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Qualcomm PD mapper";
-    homepage = "https://github.com/andersson/pd-mapper";
+    homepage = "https://github.com/linux-msm/pd-mapper";
     license = licenses.bsd3;
     platforms = platforms.aarch64;
   };
-}
+})

--- a/overlay/qrtr/qmic.nix
+++ b/overlay/qrtr/qmic.nix
@@ -1,22 +1,22 @@
 { lib, stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qmic";
-  version = "unstable-2022-07-18";
+  version = "1.0";
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "qmic";
-    rev = "ed896c97dc2b3b7edcba103e02fd0f3368b56ddd";
-    sha256 = "sha256-llum30rTCtlxN4DlLk+buv4X6FR3KY5cwuODUenwzy4=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-0/mIg98pN66ZaVsQ6KmZINuNfiKvdEHMsqDx0iciF8w=";
   };
 
   installFlags = [ "prefix=$(out)" ];
 
   meta = with lib; {
     description = "QMI IDL compiler";
-    homepage = "https://github.com/andersson/qmic";
+    homepage = "https://github.com/linux-msm/qmic";
     license = licenses.bsd3;
     platforms = platforms.aarch64;
   };
-}
+})

--- a/overlay/qrtr/qrtr.nix
+++ b/overlay/qrtr/qrtr.nix
@@ -1,22 +1,37 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, meson
+, ninja
+}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qrtr";
-  version = "unstable-2020-12-07";
+  version = "1.1";
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "qrtr";
-    rev = "9dc7a88548c27983e06465d3fbba2ba27d4bc050";
-    hash = "sha256-eJyErfLpIv4ndX2MPtjLTOQXrcWugQo/03Kz4S8S0xw=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-cPd7bd+S2uVILrFF797FwumPWBOJFDI4NvtoZ9HiWKM=";
   };
 
-  installFlags = [ "prefix=$(out)" ];
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/linux-msm/qrtr/commit/b6b586f3d099dff7c56b69c824a1931ddad170a4.patch";
+      hash = "sha256-s6FkzGf8O0gfHRH+/BHyE6taYKTfDybOJl79tR7O5y8=";
+    })
+  ];
+
+  nativeBuildInputs = [ meson ninja ];
+
+  mesonFlags = [ "-Dqrtr-ns=enabled" "-Dsystemd-service=disabled" ];
 
   meta = with lib; {
     description = "QMI IDL compiler";
-    homepage = "https://github.com/andersson/qrtr";
+    homepage = "https://github.com/linux-msm/qrtr";
     license = licenses.bsd3;
     platforms = platforms.aarch64;
   };
-}
+})

--- a/overlay/qrtr/rmtfs.nix
+++ b/overlay/qrtr/rmtfs.nix
@@ -1,15 +1,15 @@
 { stdenv, lib, fetchFromGitHub, udev, qrtr, qmic }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rmtfs";
-  version = "unstable-2022-07-18";
+  version = "1.0";
 
   buildInputs = [ udev qrtr qmic ];
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "rmtfs";
-    rev = "695d0668ffa6e2a4bf6e676f3c58a444a5d67690";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-00KOjdkwcAER261lleSl7OVDEAEbDyW9MWxDd0GI8KA=";
   };
 
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Qualcomm Remote Filesystem Service";
-    homepage = "https://github.com/andersson/rmtfs";
+    homepage = "https://github.com/linux-msm/rmtfs";
     license = licenses.bsd3;
     platforms = platforms.aarch64;
   };
-}
+})

--- a/overlay/qrtr/tqftpserv-firmware-path.diff
+++ b/overlay/qrtr/tqftpserv-firmware-path.diff
@@ -1,14 +1,13 @@
 diff --git a/translate.c b/translate.c
-index e95dee5..f3f0811 100644
+index 84a36c2..8597cbb 100644
 --- a/translate.c
 +++ b/translate.c
-@@ -45,7 +45,7 @@
- #define READONLY_PATH	"/readonly/firmware/image/"
+@@ -22,7 +22,7 @@
  #define READWRITE_PATH	"/readwrite/"
  
+ #ifndef ANDROID
 -#define FIRMWARE_BASE	"/lib/firmware/"
-+#define FIRMWARE_BASE	"/run/current-system/sw/share/uncompressed-firmware/"
- 
- /**
-  * translate_readonly() - open "file" residing with remoteproc firmware
-
++#define FIRMWARE_BASE	"@firmware_base@/"
+ #define TQFTPSERV_TMP	"/tmp/tqftpserv"
+ #else
+ #define FIRMWARE_BASE	"/vendor/firmware/"

--- a/overlay/qrtr/tqftpserv.nix
+++ b/overlay/qrtr/tqftpserv.nix
@@ -1,28 +1,40 @@
-{ stdenv, lib, fetchFromGitHub, qrtr }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, substituteAll
+, qrtr
+, zstd
+, meson
+, ninja
+, pkg-config
+, firmwareBase ? "/run/current-system/sw/share/uncompressed-firmware"
+}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tqftpserv";
-  version = "unstable-2020-02-07";
+  version = "1.1";
 
-  buildInputs = [ qrtr ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ qrtr zstd ];
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "tqftpserv";
-    rev = "783425b550de2a359db6aa3b41577c3fbaae5903";
-    hash = "sha256-Qybmd/mXhKotCem/xN0bOvWyAp2VJf+Hdh6PQyFnd3s==";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Djw2rx1FXYYPXs6Htq7jWcgeXFvfCUoeidKtYUvTqZU=";
   };
 
   patches = [
-    ./tqftpserv-firmware-path.diff
+    (substituteAll {
+      src = ./tqftpserv-firmware-path.diff;
+      firmware_base = firmwareBase;
+    })
   ];
-
-  installFlags = [ "prefix=$(out)" ];
 
   meta = with lib; {
     description = "Trivial File Transfer Protocol server over AF_QIPCRTR";
-    homepage = "https://github.com/andersson/tqftpserv";
+    homepage = "https://github.com/linux-msm/tqftpserv";
     license = licenses.bsd3;
     platforms = platforms.aarch64;
   };
-}
+})


### PR DESCRIPTION
This brings them (mostly?) in line with the postmarketOS versions. Please test this before merging, as I use mainline NixOS on my phone (it does work for me). Some packages aren't updated, but use the version number provided in git tags as opposed to unstable-...

Additionally, tqftpserv supports zstd-compressed firmware now, so it may be possible to get rid of uncompressed-firmware.