### PR TITLE
treewide: remove all uses of lib.mdDoc

### DIFF
--- a/modules/adb.nix
+++ b/modules/adb.nix
@@ -11,7 +11,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enables adbd on the device.
       '';
     };

--- a/modules/beautification.nix
+++ b/modules/beautification.nix
@@ -17,7 +17,7 @@ in
         silentBoot = mkOption {
           type = types.bool;
           default = false;
-          description = lib.mdDoc ''
+          description = ''
             When enabled, fbcon consoles are disabled.
           '';
         };
@@ -25,7 +25,7 @@ in
           type = types.bool;
           default = config.mobile.enable;
           defaultText = "config.mobile.enable";
-          description = lib.mdDoc ''
+          description = ''
             Whether silentBoot assumes the kernel logo is used as early splash,
             or leaves the fbcon unmapped such that (possibly) the vendor splash
             is kept on the display until the stage-1 boot interface starts.
@@ -42,7 +42,7 @@ in
         splash = mkOption {
           type = types.bool;
           default = false;
-          description = lib.mdDoc ''
+          description = ''
             When enabled, plymouth is configured with nice defaults.
 
             Note that this requires an update to the kernel command-line

--- a/modules/boot-control.nix
+++ b/modules/boot-control.nix
@@ -13,7 +13,7 @@ in
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc ''
+        description = ''
           Enables usage of boot-control to mark A/B boot as successful.
         '';
       };

--- a/modules/boot-initrd.nix
+++ b/modules/boot-initrd.nix
@@ -10,7 +10,7 @@ in
   options.mobile.boot = {
     stage-1.extraUtils = mkOption {
       type = types.listOf (types.either types.attrs types.package);
-      description = lib.mdDoc ''
+      description = ''
         Additional packages to be included inside stage-1.
 
         Do note that *special manipulation* happens and may
@@ -26,7 +26,7 @@ in
     stage-1.contents = mkOption {
       type = types.listOf types.attrs;
       default = [];
-      description = lib.mdDoc ''
+      description = ''
         Additional files for the initrd.
 
         See `makeInitrd` for use of `contents`.

--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -15,7 +15,7 @@ in
   options.mobile.boot = {
     defaultConsole = mkOption {
       type = with types; nullOr str;
-      description = lib.mdDoc ''
+      description = ''
         When not null, sets a `console=` parameter early in the kernel cmdline.
 
         This option is useful to control the default console that will be
@@ -35,7 +35,7 @@ in
       type = with types; listOf str;
       default = [ ];
       example = [ "ttyS0" ];
-      description = lib.mdDoc ''
+      description = ''
         List of additional console names to be prepended in the list of
         consoles in the kernel cmdline.
 
@@ -53,7 +53,7 @@ in
       type = with types; nullOr str;
       default = null;
       example = "ttyS0";
-      description = lib.mdDoc ''
+      description = ''
         The console name for the serial console. Additional parameters allowed.
 
         It will be used as an additional console by default. It can also be
@@ -63,14 +63,14 @@ in
     enableSerial = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         Whether or not to enable the serial console as an additional console.
       '';
     };
     enableDefaultSerial = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether or not to enable the serial console as an additional console.
       '';
     };

--- a/modules/bootloader.nix
+++ b/modules/bootloader.nix
@@ -10,7 +10,7 @@ in
         enable = mkOption {
           type = types.bool;
           default = config.mobile.enable;
-          description = lib.mdDoc ''
+          description = ''
             Whether the bootloader **configuration** for Mobile NixOS
             is enabled.
 

--- a/modules/devices-metadata.nix
+++ b/modules/devices-metadata.nix
@@ -13,7 +13,7 @@ in
     mobile.outputs.device-metadata = mkOption {
       type = types.package;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         The device-metadata output is used internally by the documentation
         generation to generate the per-device pages.
 

--- a/modules/generated-disk-images.nix
+++ b/modules/generated-disk-images.nix
@@ -11,14 +11,14 @@ in
   options = {
     mobile.generatedDiskImages = mkOption {
       type = types.attrsOf (pkgs.image-builder.types.disk-image);
-      description = lib.mdDoc ''
+      description = ''
         Disk image definitions that will be created at build.
       '';
     };
     mobile.outputs.generatedDiskImages = mkOption {
       type = with types; attrsOf package;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         All generated disk images from the build.
       '';
     };

--- a/modules/generated-filesystems.nix
+++ b/modules/generated-filesystems.nix
@@ -14,14 +14,14 @@ in
   options = {
     mobile.generatedFilesystems = mkOption {
       type = types.attrsOf (pkgs.image-builder.types.filesystem-image);
-      description = lib.mdDoc ''
+      description = ''
         Filesystem definitions that will be created at build.
       '';
     };
     mobile.outputs.generatedFilesystems = mkOption {
       type = with types; attrsOf package;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         All generated filesystems from the build.
       '';
     };

--- a/modules/hardware-allwinner.nix
+++ b/modules/hardware-allwinner.nix
@@ -13,12 +13,12 @@ in
     hardware.socs.allwinner-a64.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is Allwinner A64";
+      description = "enable when SOC is Allwinner A64";
     };
     hardware.socs.allwinner-r18.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is Allwinner-R18";
+      description = "enable when SOC is Allwinner-R18";
     };
   };
 

--- a/modules/hardware-eink.nix
+++ b/modules/hardware-eink.nix
@@ -11,13 +11,13 @@ in
   options.mobile.hardware.eink = {
     enable = mkOption {
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enable to change some defaults so they work better on an eink display.
       '';
     };
     enableEinkTheme = mkOption {
       default = cfg.enable;
-      description = lib.mdDoc ''
+      description = ''
         Enable only the eink changes affecting the theme.
       '';
     };

--- a/modules/hardware-exynos.nix
+++ b/modules/hardware-exynos.nix
@@ -12,7 +12,7 @@ in
     hardware.socs.exynos-7880.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is Exynos 7880";
+      description = "enable when SOC is Exynos 7880";
     };
   };
 

--- a/modules/hardware-generic.nix
+++ b/modules/hardware-generic.nix
@@ -10,19 +10,19 @@ in
     generic-x86_64.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "Enable when system is a generic x86_64";
+      description = "Enable when system is a generic x86_64";
       internal = true;
     };
     generic-aarch64.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "Enable when system is a generic AArch64";
+      description = "Enable when system is a generic AArch64";
       internal = true;
     };
     generic-armv7l.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "Enable when system is a generic armv7l";
+      description = "Enable when system is a generic armv7l";
       internal = true;
     };
   };

--- a/modules/hardware-mediatek.nix
+++ b/modules/hardware-mediatek.nix
@@ -15,22 +15,22 @@ in
     hardware.socs.mediatek-mt6755.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is Mediatek MT6755 (Helio P10)";
+      description = "enable when SOC is Mediatek MT6755 (Helio P10)";
     };
     hardware.socs.mediatek-mt6785.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is Mediatek MT6785 (Helio G90)";
+      description = "enable when SOC is Mediatek MT6785 (Helio G90)";
     };
     hardware.socs.mediatek-mt8127.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is Mediatek MT8127";
+      description = "enable when SOC is Mediatek MT8127";
     };
     hardware.socs.mediatek-mt8183.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is Mediatek MT8183";
+      description = "enable when SOC is Mediatek MT8183";
     };
   };
 

--- a/modules/hardware-qualcomm.nix
+++ b/modules/hardware-qualcomm.nix
@@ -27,52 +27,52 @@ in
     hardware.socs.qualcomm-apq8064-1aa.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is APQ8064–1AA";
+      description = "enable when SOC is APQ8064–1AA";
     };
     hardware.socs.qualcomm-msm8940.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is msm8940";
+      description = "enable when SOC is msm8940";
     };
     hardware.socs.qualcomm-msm8953.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is msm8953";
+      description = "enable when SOC is msm8953";
     };
     hardware.socs.qualcomm-msm8939.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is msm8939";
+      description = "enable when SOC is msm8939";
     };
     hardware.socs.qualcomm-msm8996.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is msm8996";
+      description = "enable when SOC is msm8996";
     };
     hardware.socs.qualcomm-msm8998.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is msm8998";
+      description = "enable when SOC is msm8998";
     };
     hardware.socs.qualcomm-sc7180.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is 7c (SC7180)";
+      description = "enable when SOC is 7c (SC7180)";
     };
     hardware.socs.qualcomm-sdm660.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is SDM660";
+      description = "enable when SOC is SDM660";
     };
     hardware.socs.qualcomm-sdm845.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is SDM845";
+      description = "enable when SOC is SDM845";
     };
     hardware.socs.qualcomm-sm6125.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is SM6125";
+      description = "enable when SOC is SM6125";
     };
   };
 

--- a/modules/hardware-ram.nix
+++ b/modules/hardware-ram.nix
@@ -9,7 +9,7 @@ in
 {
   options.mobile.hardware.ram = mkOption {
     type = types.int;
-    description = lib.mdDoc ''
+    description = ''
       Total RAM available (in MB, 1GB = 1024MB).
 
       This may be used to turn on or off features depending on the device's capabilities.

--- a/modules/hardware-rockchip.nix
+++ b/modules/hardware-rockchip.nix
@@ -18,7 +18,7 @@ in
     hardware.socs.rockchip-op1.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc "enable when SOC is RK3399-OP1";
+      description = "enable when SOC is RK3399-OP1";
     };
     hardware.socs.rockchip-rk3399s.enable = mkOption {
       type = types.bool;

--- a/modules/hardware-screen.nix
+++ b/modules/hardware-screen.nix
@@ -10,13 +10,13 @@ in
   options.mobile.hardware.screen = {
     width = mkOption {
       type = types.int;
-      description = lib.mdDoc ''
+      description = ''
         Width of the device's display.
       '';
     };
     height = mkOption {
       type = types.int;
-      description = lib.mdDoc ''
+      description = ''
         Height of the device's display.
       '';
     };

--- a/modules/hardware-soc.nix
+++ b/modules/hardware-soc.nix
@@ -9,7 +9,7 @@ in
     soc = mkOption {
       # This is used to enable a specific SOC on a device, while giving it a name.
       type = types.str;
-      description = lib.mdDoc ''
+      description = ''
         Give the SOC name for the device.
       '';
     };

--- a/modules/hardware.nix
+++ b/modules/hardware.nix
@@ -12,7 +12,7 @@ in
           type = types.listOf types.str;
           internal = true;
           default = [];
-          description = lib.mdDoc ''
+          description = ''
             Identifiers known by the boot menu to provide reboot options
             that are hardware-dependent. E.g. reboot to bootloader.
           '';

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -31,7 +31,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         enable splash and boot selection GUI
       '';
     };
@@ -39,7 +39,7 @@ in
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc ''
+        description = ''
           Whether to wait a bit for input devices before starting the user interface.
 
           This is only necessary on "slow" busses where devices may arrive a tad later than expected.
@@ -50,7 +50,7 @@ in
       delay = mkOption {
         type = types.int;
         default = 0;
-        description = lib.mdDoc ''
+        description = ''
           Minimum delay spent waiting for input devices to settle.
 
           The boot GUI will wait until this many seconds elapsed without changes before starting.
@@ -61,7 +61,7 @@ in
       type = with types; either package path;
       internal = true;
       default = ../artwork/logo/logo.white.svg;
-      description = lib.mdDoc ''
+      description = ''
         Logo shown during stage-1 init.
 
         Option marked internal since there are some particular quirks in changing the logo.

--- a/modules/initrd-fail.nix
+++ b/modules/initrd-fail.nix
@@ -9,14 +9,14 @@ in
       reboot = mkOption {
         type = types.bool;
         default = true;
-        description = lib.mdDoc ''
+        description = ''
           Reboots the device after a delay on failure.
         '';
       };
       delay = mkOption {
         type = types.int;
         default = 10;
-        description = lib.mdDoc ''
+        description = ''
           Duration (in seconds) before a reboot on failure.
         '';
       };

--- a/modules/initrd-fbterm.nix
+++ b/modules/initrd-fbterm.nix
@@ -20,14 +20,14 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enables fbterm.
       '';
     };
     fb = mkOption {
       type = types.str;
       default = "/dev/fb1";
-      description = lib.mdDoc ''
+      description = ''
         framebuffer to run fbterm on.
       '';
     };
@@ -35,7 +35,7 @@ in
       type = types.str;
       internal = true;
       default = "2";
-      description = lib.mdDoc ''
+      description = ''
         The tty to run on. This will be switched for you.
 
         This is used to side-step an issue where X11 will not start

--- a/modules/initrd-firmware.nix
+++ b/modules/initrd-firmware.nix
@@ -9,7 +9,7 @@ in
     mobile.boot.stage-1.firmware = lib.mkOption {
       type = types.listOf types.package;
       default = [];
-      description = lib.mdDoc ''
+      description = ''
         List of packages containing firmware files to be included in the
         stage-1 for the device.
       '';

--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -29,7 +29,7 @@ in
       type = types.bool;
       default = !config.mobile.enable;
       defaultText = literalExpression "!config.mobile.enable";
-      description = lib.mdDoc ''
+      description = ''
         Whether Mobile NixOS relies on upstream NixOS settings for kernel config.
 
         Enable this when using the NixOS machinery for kernels.
@@ -38,7 +38,7 @@ in
     modular = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether the kernel is built with modules or not.
         This will enable modules closure generation and listing modules
         to bundle and load.
@@ -48,7 +48,7 @@ in
       type = types.listOf types.str;
       default = [
       ];
-      description = lib.mdDoc ''
+      description = ''
         Module names to add to the closure.
         They will be modprobed.
       '';
@@ -57,7 +57,7 @@ in
       type = types.listOf types.str;
       default = [
       ];
-      description = lib.mdDoc ''
+      description = ''
         Module names to add to the closure.
         They will not be modprobed.
       '';
@@ -65,7 +65,7 @@ in
     allowMissingModules = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         Chooses whether the modules closure build fails if a module is missing.
       '';
     };
@@ -74,7 +74,7 @@ in
     package = mkOption {
       type = types.nullOr types.package;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Kernel to be used by the system-type to boot into the Mobile NixOS
         stage-1.
 
@@ -84,7 +84,7 @@ in
     useStrictKernelConfig = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether or not to fail when the config file differs when built.
 
         When building a personal configuration, this should be disabled (`false`)
@@ -103,14 +103,14 @@ in
       linuxLogo224PPMFile = mkOption {
         type = types.package;
         internal = true;
-        description = lib.mdDoc ''
+        description = ''
           Final logo file consumed by the Mobile NixOS kernel-builder infra.
         '';
       };
       logo = mkOption {
         type = with types; either package path;
         internal = true;
-        description = lib.mdDoc ''
+        description = ''
           Input file for the logo.
 
           It will be scaled according to the device-specific configuration.

--- a/modules/initrd-logs.nix
+++ b/modules/initrd-logs.nix
@@ -10,14 +10,14 @@ in
     enable = mkOption {
       type = types.bool;
       default = config.mobile.boot.stage-1.enable;
-      description = lib.mdDoc ''
+      description = ''
         Enables bootlogd logging multiplexer.
       '';
     };
     kmsg = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enables logging to /dev/kmsg.
 
         Note that this may render switching to stage-2 inoperable.

--- a/modules/initrd-network.nix
+++ b/modules/initrd-network.nix
@@ -12,21 +12,21 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enables networking.
       '';
     };
     IP = mkOption {
       type = types.str;
       default = "172.16.42.1";
-      description = lib.mdDoc ''
+      description = ''
         IP address for the USB networking gadget.
       '';
     };
     hostIP = mkOption {
       type = types.str;
       default = "172.16.42.2";
-      description = lib.mdDoc ''
+      description = ''
         IP address for the USB networking gadget.
       '';
     };

--- a/modules/initrd-shell.nix
+++ b/modules/initrd-shell.nix
@@ -9,7 +9,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enables a shell before switching root.
 
         This shell (as currently configured) will not allow switching root.
@@ -18,7 +18,7 @@ in
     console = mkOption {
       type = types.str;
       default = "console";
-      description = lib.mdDoc ''
+      description = ''
         Selects the /dev/___ device to use.
 
         Use `ttyS0` for serial, `tty1` for first VT or keep the default to `console`
@@ -29,7 +29,7 @@ in
     shellOnFail = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enables a shell on failures.
       '';
     };

--- a/modules/initrd-ssh.nix
+++ b/modules/initrd-ssh.nix
@@ -16,7 +16,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enables ssh during stage-1.
 
         **CURRENT CONFIGURATION ALSO OPENS ACCESS TO ALL WITHOUT A PASSWORD NOR SSH KEY.**

--- a/modules/initrd-usb.nix
+++ b/modules/initrd-usb.nix
@@ -17,7 +17,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         Enables USB features.
         For now, only Android-based devices are supported.
       '';
@@ -25,7 +25,7 @@ in
     features = mkOption {
       type = types.listOf types.str;
       default = [];
-      description = lib.mdDoc ''
+      description = ''
         `android_usb` features to enable.
       '';
     };
@@ -33,26 +33,26 @@ in
   options.mobile.usb = {
     idVendor = mkOption {
       type = types.str;
-      description = lib.mdDoc ''
+      description = ''
         USB vendor ID for the USB gadget.
       '';
     };
     idProduct = mkOption {
       type = types.str;
-      description = lib.mdDoc ''
+      description = ''
         USB product ID for the USB gadget.
       '';
     };
     mode = mkOption {
       type = types.nullOr (types.enum [ "android_usb" "gadgetfs" ]);
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         The USB gadget implementation the device uses.
       '';
     };
     gadgetfs.functions = mkOption {
       type = types.attrs;
-      description = lib.mdDoc ''
+      description = ''
         Mapping of logical gadgetfs functions to their implementation names.
       '';
     };

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -236,7 +236,7 @@ in
       mobile.boot.stage-1.enable = mkOption {
         type = types.bool;
         default = config.mobile.enable;
-        description = lib.mdDoc ''
+        description = ''
           Whether to use the Mobile NixOS stage-1 implementation or not.
 
           This will forcible override the NixOS stage-1 when enabled.
@@ -246,7 +246,7 @@ in
       mobile.boot.stage-1.stage = mkOption {
         type = types.enum [ 0 1 ];
         default = 1;
-        description = lib.mdDoc ''
+        description = ''
           Used with a "specialization" of the config to build the "stage-0"
           init which can kexec into another kernel+initrd found on the system.
 
@@ -257,7 +257,7 @@ in
       mobile.boot.stage-1.compression = mkOption {
         type = types.enum [ "gzip" "xz" ];
         default = "gzip";
-        description = lib.mdDoc ''
+        description = ''
           The compression method for the stage-1 (initrd).
 
           This may be set as a default by some devices requiring specific
@@ -268,7 +268,7 @@ in
         type = with types; listOf (either package path);
         default = [];
         internal = true;
-        description = lib.mdDoc ''
+        description = ''
           Add tasks to the boot/init program.
           The build system for boot/init will `find -iname '*.rb'` the given paths.
         '';
@@ -277,14 +277,14 @@ in
         type = JSONValue;
         default = {};
         internal = true;
-        description = lib.mdDoc ''
+        description = ''
           The things being put in the JSON configuration file in stage-1.
         '';
       };
       mobile.boot.stage-1.crashToBootloader = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc ''
+        description = ''
           When the stage-1 bootloader crashes, prefer rebooting directly to
           bootloader rather than panic by killing init.
 
@@ -297,7 +297,7 @@ in
       mobile.boot.stage-1.earlyInitScripts = mkOption {
         type = types.lines;
         default = "";
-        description = lib.mdDoc ''
+        description = ''
           Additional shell commands to run before the actual init.
 
           Prefer writing a task. This should be used mainly to redirect logging,
@@ -308,7 +308,7 @@ in
       };
       mobile.boot.stage-1.environment = mkOption {
         type = types.attrsOf types.str;
-        description = lib.mdDoc ''
+        description = ''
           Environment variables present for the whole stage-1.
           Keep this as minimal as needed.
         '';
@@ -317,7 +317,7 @@ in
       mobile.boot.stage-1.extraUdevRules = mkOption {
         type = types.lines;
         default = "";
-        description = lib.mdDoc ''
+        description = ''
           Additional udev rules for stage-1.
         '';
         internal = true;
@@ -327,7 +327,7 @@ in
         extraUtils = mkOption {
           type = types.package;
           internal = true;
-          description = lib.mdDoc ''
+          description = ''
             Stripped packages for use in stage-1.
 
             See `mobile.boot.stage-1.extraUtils`.
@@ -336,14 +336,14 @@ in
         initrd = mkOption {
           type = types.str;
           internal = true;
-          description = lib.mdDoc ''
+          description = ''
             Path to the initrd, likely compressed, for the system.
           '';
         };
         initrd-meta = mkOption {
           type = types.package;
           internal = true;
-          description = lib.mdDoc ''
+          description = ''
             Additional metadata about the initrd; used for debugging.
           '';
         };

--- a/modules/kernel-config.nix
+++ b/modules/kernel-config.nix
@@ -12,7 +12,7 @@ in
       kernel = {
         structuredConfig = mkOption {
           type = with types; listOf (functionTo attrs);
-          description = lib.mdDoc ''
+          description = ''
             Functions returning kernel structured config.
 
             The functions take one argument, an attrset of helpers.

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -15,24 +15,24 @@ in
   options.mobile.device = {
     name = mkOption {
       type = types.str;
-      description = lib.mdDoc "The device's codename. Must match the device folder.";
+      description = "The device's codename. Must match the device folder.";
     };
 
     identity = {
       name = mkOption {
         type = types.str;
-        description = lib.mdDoc "The device's name as advertised by the manufacturer.";
+        description = "The device's name as advertised by the manufacturer.";
       };
       manufacturer = mkOption {
         type = types.str;
-        description = lib.mdDoc "The device's manufacturer name.";
+        description = "The device's manufacturer name.";
       };
     };
 
     firmware = mkOption {
       type = types.nullOr types.package;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Informal option that the end-user can use to get their device's firmware package.
 
         The firmware will be added to `hardware.firmware` automatically for most devices.
@@ -44,7 +44,7 @@ in
 
     enableFirmware = mkOption {
       type = types.bool;
-      description = lib.mdDoc ''
+      description = ''
         Enable automatically adding the firmware to the system configuration.
 
         This may be disabled by some devices that require manual operations
@@ -57,7 +57,7 @@ in
     supportLevel = mkOption {
       type = types.enum [ "supported" "best-effort" "broken" "vendor" "unsupported" "abandoned" ];
       default = "unsupported";
-      description = lib.mdDoc ''
+      description = ''
         Support level for the device.
       '';
     };

--- a/modules/mobile.nix
+++ b/modules/mobile.nix
@@ -12,7 +12,7 @@ in
       enable = mkOption {
         type = types.bool;
         default = true;
-        description = lib.mdDoc ''
+        description = ''
           When this setting is set to false, including Mobile
           NixOS in your NixOS configuration should be a no-op.
         '';
@@ -20,7 +20,7 @@ in
       configurationName = mkOption {
         internal = true;
         default = "mobile-nixos";
-        description = lib.mdDoc ''
+        description = ''
           Used for some identifiers like the image name.
 
           This is used in example systems to change the name of the produced

--- a/modules/outputs.nix
+++ b/modules/outputs.nix
@@ -10,7 +10,7 @@ in
     mobile = {
       outputs = {
         default = mkOption {
-          description = lib.mdDoc ''
+          description = ''
             Default most likely desired output for this Mobile NixOS build.
 
             The default depends on the system type in use.
@@ -19,7 +19,7 @@ in
           internal = true;
         };
         toplevel = mkOption {
-          description = lib.mdDoc ''
+          description = ''
             First-class attribute to refer to `config.system.build.toplevel`.
           '';
           internal = true;

--- a/modules/quirks/audio.nix
+++ b/modules/quirks/audio.nix
@@ -9,7 +9,7 @@ in
     alsa-ucm-meld = lib.mkOption {
       type = lib.types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Combines the derivation output path share/alsa/ucm2/ with
         pkgs.alsa-ucm-conf and points ALSA to the result.
       '';

--- a/modules/quirks/exynos/exynos-fb-notify.nix
+++ b/modules/quirks/exynos/exynos-fb-notify.nix
@@ -9,7 +9,7 @@ in
     quirks.exynos.fb-notify.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enable this on a device which requires the framebuffer
         to be notified for some components to work right.
 

--- a/modules/quirks/framebuffer.nix
+++ b/modules/quirks/framebuffer.nix
@@ -14,7 +14,7 @@ in
     quirks.fb-refresher.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enables use of `msm-fb-refresher`.
         Use sparingly, it is better to patch software to flip buffers instead.
 
@@ -25,7 +25,7 @@ in
     quirks.fb-refresher.stage-1.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Add `msm-fb-refresher` to stage-1.
 
         It should not be needed for the usual assortment of Mobile NixOS tools.

--- a/modules/quirks/qualcomm/msm-dwc3.nix
+++ b/modules/quirks/qualcomm/msm-dwc3.nix
@@ -9,7 +9,7 @@ in
     quirks.qualcomm.dwc3-otg_switch.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enable this on a device which requires otg_switch to be
         configured for OTG to work.
       '';

--- a/modules/quirks/qualcomm/msm-fb-notify.nix
+++ b/modules/quirks/qualcomm/msm-fb-notify.nix
@@ -9,7 +9,7 @@ in
     quirks.qualcomm.fb-notify.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enable this on a device which requires the framebuffer
         to be notified for some components to work right.
 

--- a/modules/quirks/qualcomm/sdm845-modem.nix
+++ b/modules/quirks/qualcomm/sdm845-modem.nix
@@ -33,14 +33,14 @@ in
     quirks.qualcomm.sc7180-modem.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enable this on a mainline-based SC7180 device for modem/Wi-Fi support
       '';
     };
     quirks.qualcomm.sdm845-modem.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enable this on a mainline-based SDM845 device for modem support
       '';
     };

--- a/modules/quirks/qualcomm/wcnss-wlan.nix
+++ b/modules/quirks/qualcomm/wcnss-wlan.nix
@@ -9,7 +9,7 @@ in
     quirks.qualcomm.wcnss-wlan.enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enable this on a device which uses wcnss wlan.
       '';
     };

--- a/modules/quirks/wifi.nix
+++ b/modules/quirks/wifi.nix
@@ -9,7 +9,7 @@ in
     disableMacAddressRandomization = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Disables MAC address randomization.
 
         This may be required by some hardware or drivers, or combination.

--- a/modules/recovery.nix
+++ b/modules/recovery.nix
@@ -14,7 +14,7 @@ in
       outputs = {
         recovery = mkOption {
           internal = true;
-          description = lib.mdDoc ''
+          description = ''
             The configuration, re-evaluated with assumptions for recovery use.
           '';
         };

--- a/modules/rootfs.nix
+++ b/modules/rootfs.nix
@@ -15,7 +15,7 @@ in
         enableDefaultConfiguration = mkOption {
           type = types.bool;
           default = config.mobile.enable;
-          description = lib.mdDoc ''
+          description = ''
             Whether some of the rootfs configuration is managed by Mobile NixOS or not.
           '';
         };
@@ -23,7 +23,7 @@ in
           type = types.bool;
           default = config.nix.enable;
           defaultText = lib.literalExpression "config.nix.enable";
-          description = lib.mdDoc ''
+          description = ''
             Whether to rehydrate the store at first boot or not.
 
             The only reason you would disable this is to build a target system that has no Nix binaries.

--- a/modules/shared-rootfs.nix
+++ b/modules/shared-rootfs.nix
@@ -10,7 +10,7 @@ in
       internal = true;
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Enable when building a generic rootfs that does not include a kernel image.
 
         This makes sturdier rootfs that work on different devices.

--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -24,7 +24,7 @@ in
     mobile.quirks.supportsStage-0 = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Set to true when a device, and its kernel, can use kexec.
 
         This will enable booting into the generation's kernel.
@@ -35,7 +35,7 @@ in
       nodes = mkOption {
         type = types.listOf types.str;
         default = [];
-        description = lib.mdDoc ''
+        description = ''
           FDT nodes to forward to the kexec'd system.
         '';
       };
@@ -45,7 +45,7 @@ in
         example = [
           ["/soc/mmc@1c10000/wifi@1" "local-mac-address"]
         ];
-        description = lib.mdDoc ''
+        description = ''
           Pair of [node prop] to forward to the kexec'd system.
 
           Only the prop described on the exact node will be forwarded.
@@ -57,7 +57,7 @@ in
       outputs = {
         stage-0 = mkOption {
           internal = true;
-          description = lib.mdDoc ''
+          description = ''
             The configuration, re-evaluated with assumptions for stage-0 use.
           '';
         };

--- a/modules/system-target.nix
+++ b/modules/system-target.nix
@@ -22,7 +22,7 @@ in
         "armv7l-linux"
         "x86_64-linux"
       ];
-      description = lib.mdDoc ''
+      description = ''
         Defines the kind of target architecture system the device is.
 
         This will automagically setup cross-compilation where possible.

--- a/modules/system-types.nix
+++ b/modules/system-types.nix
@@ -23,13 +23,13 @@ in
     system.types = mkOption {
       type = types.listOf types.str;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         Registry of system types.
       '';
     };
     system.type = mkOption {
       type = types.enum known_system_types;
-      description = lib.mdDoc ''
+      description = ''
         Defines the kind of system the device is.
 
         The different kind of system types will define the outputs

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -88,21 +88,21 @@ in
     mobile.system.android = {
       ab_partitions = lib.mkOption {
         type = types.bool;
-        description = lib.mdDoc "Configures whether the device uses an A/B partition scheme";
+        description = "Configures whether the device uses an A/B partition scheme";
         default = false;
         internal = true;
       };
 
       boot_as_recovery = lib.mkOption {
         type = types.bool;
-        description = lib.mdDoc "Configures whether the device uses 'boot as recovery'";
+        description = "Configures whether the device uses 'boot as recovery'";
         default = config.mobile.system.android.ab_partitions;
         internal = true;
       };
 
       device_name = lib.mkOption {
         type = types.nullOr types.str;
-        description = lib.mdDoc "Value of `ro.product.device` or `ro.build.product`. Used to compare against in flashable zips.";
+        description = "Value of `ro.product.device` or `ro.build.product`. Used to compare against in flashable zips.";
         default = null;
         internal = true;
       };
@@ -113,28 +113,28 @@ in
           "lk2nd"    # Some Qualcomm mainline devices, using fastboot and lk2nd
           "odin"     # Mainly Samsung, using `heimdall`
         ];
-        description = lib.mdDoc "Configures which flashing method is used by the device.";
+        description = "Configures which flashing method is used by the device.";
         default = "fastboot";
         internal = true;
       };
 
       has_recovery_partition = lib.mkOption {
         type = types.bool;
-        description = lib.mdDoc "Configures whether the device uses a distinct recovery partition";
+        description = "Configures whether the device uses a distinct recovery partition";
         default = !config.mobile.system.android.boot_as_recovery;
         internal = true;
       };
 
       boot_partition_destination = lib.mkOption {
         type = types.str;
-        description = lib.mdDoc "Partition label on which to install the boot image. Some OEM name the partition BOOT.";
+        description = "Partition label on which to install the boot image. Some OEM name the partition BOOT.";
         default = "boot";
         internal = true;
       };
 
       system_partition_destination = lib.mkOption {
         type = types.str;
-        description = lib.mdDoc "Partition label on which to install the system image. E.g. change to `userdata` when it does not fit in the system partition.";
+        description = "Partition label on which to install the system image. E.g. change to `userdata` when it does not fit in the system partition.";
         default = "system";
         internal = true;
       };
@@ -142,7 +142,7 @@ in
       bootimg = {
         name = lib.mkOption {
           type = types.str;
-          description = lib.mdDoc "Suffix for the image name. Use it to distinguish speciality boot images.";
+          description = "Suffix for the image name. Use it to distinguish speciality boot images.";
           default = "boot.img";
           internal = true;
         };
@@ -150,7 +150,7 @@ in
         dt = lib.mkOption {
           type = types.nullOr types.path;
           default = null;
-          description = lib.mdDoc "Path to a flattened device tree to pass as --dt to mkbootimg";
+          description = "Path to a flattened device tree to pass as --dt to mkbootimg";
           internal = true;
         };
 
@@ -167,7 +167,7 @@ in
       appendDTB = lib.mkOption {
         type = with types; nullOr (listOf (oneOf [path str]));
         default = null;
-        description = lib.mdDoc "List of dtb files to append to the kernel, when device uses appended DTB.";
+        description = "List of dtb files to append to the kernel, when device uses appended DTB.";
       };
     };
     mobile = {
@@ -175,21 +175,21 @@ in
         android = {
           android-bootimg = lib.mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               `boot.img` type image for Android-based systems.
             '';
             visible = false;
           };
           android-recovery = lib.mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               `recovery.img` type image for Android-based systems.
             '';
             visible = false;
           };
           android-fastboot-images = lib.mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               Flashing scripts and images for use with fastboot or odin.
             '';
             visible = false;

--- a/modules/system-types/android/flashable-zip.nix
+++ b/modules/system-types/android/flashable-zip.nix
@@ -68,21 +68,21 @@ in
         android = {
           android-flashable-bootimg = mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               `boot.img` in Android flashable zip format.
             '';
             visible = false;
           };
           android-flashable-system = mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               `system.img` in Android flashable zip format.
             '';
             visible = false;
           };
           android-flashable-zip = mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               Android flashable zip which will install `boot.img` and `system.img`.
             '';
             visible = false;

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -102,14 +102,14 @@ in
         depthcharge = {
           disk-image = mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               Full Mobile NixOS disk image for a depthcharge-based system.
             '';
             visible = false;
           };
           kpart = mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               Kernel partition for a depthcharge-based system.
             '';
             visible = false;

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -110,7 +110,7 @@ in
       additionalCommands = mkOption {
         type = types.lines;
         default = "";
-        description = lib.mdDoc ''
+        description = ''
           Additional U-Boot commands to run.
         '';
       };
@@ -120,21 +120,21 @@ in
       u-boot = {
         boot-partition = mkOption {
           type = types.package;
-          description = lib.mdDoc ''
+          description = ''
             Boot partition for the system.
           '';
           visible = false;
         };
         disk-image = lib.mkOption {
           type = types.package;
-          description = lib.mdDoc ''
+          description = ''
             Full Mobile NixOS disk image for a u-boot-based system.
           '';
           visible = false;
         };
         u-boot = mkOption {
           type = types.package;
-          description = lib.mdDoc ''
+          description = ''
             U-Boot build for the system.
           '';
           visible = false;

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -92,21 +92,21 @@ in
       uefi = {
         boot-partition = mkOption {
           type = types.package;
-          description = lib.mdDoc ''
+          description = ''
             Boot partition for the system.
           '';
           visible = false;
         };
         disk-image = lib.mkOption {
           type = types.package;
-          description = lib.mdDoc ''
+          description = ''
             Full Mobile NixOS disk image for a UEFI-based system.
           '';
           visible = false;
         };
         efiKernel = mkOption {
           type = types.package;
-          description = lib.mdDoc ''
+          description = ''
             EFI executable with the kernel, cmdline and initramfs built-in.
           '';
           visible = false;

--- a/modules/system-types/uefi/vm.nix
+++ b/modules/system-types/uefi/vm.nix
@@ -16,7 +16,7 @@ in
         type = types.bool;
         default = false;
         internal = true;
-        description = lib.mdDoc ''
+        description = ''
           Internal switch to select whether the `outputs.uefi.vm` value points
           to the composeConfig usage, or to the actual output.
         '';
@@ -25,7 +25,7 @@ in
         uefi = {
           vm = mkOption {
             type = types.package;
-            description = lib.mdDoc ''
+            description = ''
               Script to start a UEFI-based virtual machine.
             '';
             visible = false;

--- a/overlay/image-builder/disk-image/basic.nix
+++ b/overlay/image-builder/disk-image/basic.nix
@@ -17,7 +17,7 @@ in
     alignment = mkOption {
       type = types.int;
       default = config.helpers.size.MiB 1;
-      description = lib.mdDoc ''
+      description = ''
         Partitions alignment.
 
         Automatically computed partition start position will be aligned to
@@ -31,7 +31,7 @@ in
       type = types.int;
       default = 512;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         Sector size. This is used mainly internally. Changing this should have
         no effects on the actual disk image produced.
 
@@ -42,7 +42,7 @@ in
     location = mkOption {
       type = types.str;
       default = "";
-      description = lib.mdDoc ''
+      description = ''
         Location of the image in the `$out` path.
 
         The default value means that `$img == $out`, which means that the
@@ -58,7 +58,7 @@ in
     output = mkOption {
       type = types.package;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         The build output for the disk image.
       '';
     };
@@ -68,7 +68,7 @@ in
       default = "${config.output}${config.location}";
       defaultText = lib.literalExpression "\"\${config.output}\${config.location}\"";
       readOnly = true;
-      description = lib.mdDoc ''
+      description = ''
         Output path for the image file.
       '';
     };
@@ -76,7 +76,7 @@ in
     additionalCommands = mkOption {
       type = types.lines;
       default = "";
-      description = lib.mdDoc ''
+      description = ''
         Additional commands to run during the disk image build.
       '';
     };
@@ -86,7 +86,7 @@ in
     #   type = types.bool;
     #   default = false;
     #   internal = true;
-    #   description = lib.mdDoc ''
+    #   description = ''
     #     Whether to produce discrete derivations for each steps, or to produce
     #     a single derivation that builds the image from A to Z.
     #

--- a/overlay/image-builder/disk-image/partitioning-scheme/default.nix
+++ b/overlay/image-builder/disk-image/partitioning-scheme/default.nix
@@ -19,7 +19,7 @@ in
     };
     partitioningScheme = mkOption {
       type = types.enum config.availablePartitioningSchemes;
-      description = lib.mdDoc ''
+      description = ''
         Partitioning scheme for the disk image output.
       '';
     };

--- a/overlay/image-builder/disk-image/partitioning-scheme/gpt/default.nix
+++ b/overlay/image-builder/disk-image/partitioning-scheme/gpt/default.nix
@@ -14,7 +14,7 @@ in
     diskID = mkOption {
       type = types.nullOr config.helpers.types.uuid;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Identifier for the disk.
       '';
     };
@@ -22,7 +22,7 @@ in
     partitionEntriesCount = mkOption {
       type = types.int;
       default = 128;
-      description = lib.mdDoc ''
+      description = ''
         Number of partitions in the partition table.
 
         The default value is likely appropriate.
@@ -33,7 +33,7 @@ in
       type = with types; listOf str;
       default = [];
       example = [ "1" "3" "6" "EE" ];
-      description = lib.mdDoc ''
+      description = ''
         Creates an hybrid MBR with the given (string) partition numbers.
 
         Up to three partitions can be present in the hybrid MBR, an additional

--- a/overlay/image-builder/disk-image/partitioning-scheme/mbr/default.nix
+++ b/overlay/image-builder/disk-image/partitioning-scheme/mbr/default.nix
@@ -17,7 +17,7 @@ in
           "${hex}{8}"
       );
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Identifier for the disk.
       '';
     };

--- a/overlay/image-builder/disk-image/partitions.nix
+++ b/overlay/image-builder/disk-image/partitions.nix
@@ -14,7 +14,7 @@ let
     options = {
       name = mkOption {
         type = types.str;
-        description = lib.mdDoc ''
+        description = ''
           Identifier for the partition.
         '';
       };
@@ -23,7 +23,7 @@ let
         type = types.str;
         default = config.name;
         defaultText = lib.literalExpression "config.name";
-        description = lib.mdDoc ''
+        description = ''
           Partition label on supported partition schemes. Defaults to ''${name}.
 
           Not to be confused with _filesystem_ label.
@@ -33,7 +33,7 @@ let
       partitionUUID = mkOption {
         type = types.nullOr helpers.types.uuid;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Partition UUID, for supported partition schemes.
 
           Not to be confused with _filesystem_ UUID.
@@ -45,7 +45,7 @@ let
       length = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Size in bytes for the partition.
 
           Defaults to the filesystem image length (computed at runtime).
@@ -55,7 +55,7 @@ let
       offset = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Offset (in bytes) the partition starts at.
 
           Defaults to the next aligned location on disk.
@@ -69,7 +69,7 @@ let
         ];
         default = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
         defaultText = "Linux filesystem data (0FC63DAF-8483-4772-8E79-3D69D8477DE4)";
-        description = lib.mdDoc ''
+        description = ''
           Partition type UUID.
 
           Not to be confused with _partitionUUID_.
@@ -81,7 +81,7 @@ let
       bootable = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc ''
+        description = ''
           Sets the "legacy bios bootable flag" on the partition.
         '';
       };
@@ -89,7 +89,7 @@ let
       requiredPartition = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc ''
+        description = ''
           For GPT, sets the Required Partition attribute on the partition.
         '';
       };
@@ -100,7 +100,7 @@ let
           _module.args.pkgs = pkgs;
         }));
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           A filesystem image configuration.
 
           The filesystem image produced by this configuration is the default
@@ -111,7 +111,7 @@ let
       isGap = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc ''
+        description = ''
           When set to true, only the length attribute is used, and describes
           an unpartitioned span in the disk image.
         '';
@@ -121,7 +121,7 @@ let
         type = with types; nullOr (oneOf [ package path ]);
         defaultText = "[contents of the filesystem attribute]";
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Raw image to be used as the partition content.
 
           By default uses the output of the `filesystem` submodule.
@@ -141,7 +141,7 @@ in
   options = {
     partitions = mkOption {
       type = with types; listOf (submodule partitionSubmodule);
-      description = lib.mdDoc ''
+      description = ''
         List of partitions to include in the disk image.
       '';
     };

--- a/overlay/image-builder/filesystem-image/basic.nix
+++ b/overlay/image-builder/filesystem-image/basic.nix
@@ -24,7 +24,7 @@ in
     label = mkOption {
       type = with types; nullOr str;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Filesystem label
 
         Not to be confused with either the output name, or the partition label.
@@ -34,7 +34,7 @@ in
     sectorSize = mkOption {
       type = types.int;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         Default value should probably not be changed. Used internally for some
         automatic size maths.
       '';
@@ -43,7 +43,7 @@ in
     blockSize = mkOption {
       type = types.int;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         Used with the assumption that files are rounded up to blockSize increments.
       '';
     };
@@ -52,7 +52,7 @@ in
       type = with types; nullOr int;
       default = null;
       defaultText = "[automatically computed]";
-      description = lib.mdDoc ''
+      description = ''
         When null, size is computed automatically.
 
         Otherwise sets the size of the filesystem image.
@@ -65,7 +65,7 @@ in
     computeMinimalSize = mkOption {
       internal = true;
       type = types.str;
-      description = lib.mdDoc ''
+      description = ''
         Filesystem-specific snippet to adapt the size of the filesystem image
         so the content can fit.
       '';
@@ -74,7 +74,7 @@ in
     extraPadding = mkOption {
       type = types.int;
       default = 0;
-      description = lib.mdDoc ''
+      description = ''
         When size is computed automatically, how many bytes to add to the
         filesystem total size.
       '';
@@ -84,7 +84,7 @@ in
       type = types.int;
       internal = true;
       default = 0;
-      description = lib.mdDoc ''
+      description = ''
         Minimum usable size the filesystem must have. "Usable" here may not
         actually be useful.
       '';
@@ -94,7 +94,7 @@ in
       type = types.lines;
       internal = true;
       default = "";
-      description = lib.mdDoc ''
+      description = ''
         Bash functions required by the builder.
       '';
     };
@@ -102,7 +102,7 @@ in
     buildPhases = mkOption {
       type = with types; lazyAttrsOf str;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         Implementation of build phases for the filesystem image.
       '';
     };
@@ -110,7 +110,7 @@ in
     buildPhasesOrder = mkOption {
       type = with types; listOf str;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         Order of the filesystem image build phase. Adding to this is likely to
         cause issues. Use this sparingly, and as a last resort.
       '';
@@ -119,7 +119,7 @@ in
     populateCommands = lib.mkOption {
       type = types.lines;                  
       default = "";
-      description = lib.mdDoc ''
+      description = ''
         Commands used to fill the filesystem.
 
         `$PWD` is the root of the filesystem.
@@ -129,7 +129,7 @@ in
     buildInputs = mkOption {
       type = with types; listOf package;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         Allows adding to the builder buildInputs.
       '';
     };
@@ -137,7 +137,7 @@ in
     nativeBuildInputs = mkOption {
       type = with types; listOf package;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         Allows adding to the builder nativeBuildInputs.
 
         As this list is built without *splicing*, use `pkgs.buildPackages` as
@@ -148,7 +148,7 @@ in
     location = mkOption {
       type = types.str;
       default = "";
-      description = lib.mdDoc ''
+      description = ''
         Location of the image in the `$out` path.
 
         The default value means that `$img == $out`, which means that the
@@ -164,7 +164,7 @@ in
     output = mkOption {
       type = types.package;
       internal = true;
-      description = lib.mdDoc ''
+      description = ''
         The build output for the filesystem image.
       '';
     };
@@ -174,7 +174,7 @@ in
       default = "${config.output}${config.location}";
       defaultText = lib.literalExpression "\"\${config.output}\${config.location}\"";
       readOnly = true;
-      description = lib.mdDoc ''
+      description = ''
         Output path for the image file.
       '';
     };
@@ -182,7 +182,7 @@ in
     additionalCommands = mkOption {
       type = types.lines;
       default = "";
-      description = lib.mdDoc ''
+      description = ''
         Additional commands to run during the filesystem image build.
       '';
     };

--- a/overlay/image-builder/filesystem-image/filesystem/btrfs.nix
+++ b/overlay/image-builder/filesystem-image/filesystem/btrfs.nix
@@ -20,7 +20,7 @@ in
       type = types.nullOr config.helpers.types.uuid;
       example = "45454545-4545-4545-4545-454545454545";
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Volume ID of the filesystem.
       '';
     };

--- a/overlay/image-builder/filesystem-image/filesystem/default.nix
+++ b/overlay/image-builder/filesystem-image/filesystem/default.nix
@@ -21,7 +21,7 @@ in
     };
     filesystem = mkOption {
       type = types.enum config.availableFilesystems;
-      description = lib.mdDoc ''
+      description = ''
         Filesystem used in this filesystem image.
       '';
     };

--- a/overlay/image-builder/filesystem-image/filesystem/ext4.nix
+++ b/overlay/image-builder/filesystem-image/filesystem/ext4.nix
@@ -54,7 +54,7 @@ in
       type = types.nullOr config.helpers.types.uuid;
       example = "45454545-4545-4545-4545-454545454545";
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Volume ID of the filesystem.
       '';
     };

--- a/overlay/image-builder/filesystem-image/filesystem/fat32.nix
+++ b/overlay/image-builder/filesystem-image/filesystem/fat32.nix
@@ -47,7 +47,7 @@ in
       example = "2e24ec82";
       default = null;
       defaultText = "[Depends on the file system creation time]";
-      description = lib.mdDoc ''
+      description = ''
         Volume ID of the filesystem.
 
         The default is a number which depends on the file system creation time.

--- a/overlay/image-builder/filesystem-image/filesystem/squashfs.nix
+++ b/overlay/image-builder/filesystem-image/filesystem/squashfs.nix
@@ -24,7 +24,7 @@ in
         "zstd"
       ];
       default = "xz";
-      description = lib.mdDoc ''
+      description = ''
         Volume ID of the filesystem.
       '';
     };

--- a/overlay/mobile-nixos/kernel/eval-config.nix
+++ b/overlay/mobile-nixos/kernel/eval-config.nix
@@ -147,14 +147,14 @@
             configfile = lib.mkOption {
               readOnly = true;
               type = lib.types.str;
-              description = lib.mdDoc ''
+              description = ''
                 String that can directly be used as a kernel config file contents.
               '';
             };
             validatorSnippet = lib.mkOption {
               readOnly = true;
               type = lib.types.package;
-              description = lib.mdDoc ''
+              description = ''
                 Path to a script that can directly be called to validate the kernel config.
               '';
             };


### PR DESCRIPTION
This change should be a no-op, as lib.mdDoc is defined to be the identity function in the current Nixpkgs version.