### PR TITLE
support/kernel-config: replace Unicode space in comment with ASCII space

### DIFF
--- a/support/kernel-config/nixos.nix
+++ b/support/kernel-config/nixos.nix
@@ -85,7 +85,7 @@ in
       USB_DEBUG = { optional = true; tristate = whenOlder "4.18" "n";};
       USB_EHCI_ROOT_HUB_TT = option yes; # Root Hub Transaction Translators
       USB_EHCI_TT_NEWSCHED = option yes; # Improved transaction translator scheduling
-      USB_HIDDEV = yes; # USB Raw HID Devices (like monitor controls and Uninterruptable Power Supplies)
+      USB_HIDDEV = yes; # USB Raw HID Devices (like monitor controls and Uninterruptable Power Supplies)
 
       # security
       FORTIFY_SOURCE                   = option yes;


### PR DESCRIPTION
Replace [No-Break Space](https://symbl.cc/en/00A0/) with normal space.