### PR TITLE
Remove deprecated File.exists? from Ruby code

### DIFF
--- a/bin/kernel-normalize-config
+++ b/bin/kernel-normalize-config
@@ -97,7 +97,7 @@ unless ONLY_CHECK
       ].shelljoin}`.strip
   end
 
-  unless @file and File.exists?(@file)
+  unless @file and File.exist?(@file)
     $stderr.puts "Kernel config file not found."
     $stderr.puts "Please provide path to the config file with `--file=...`."
     $stderr.puts

--- a/boot/init/lib/system.rb
+++ b/boot/init/lib/system.rb
@@ -79,7 +79,7 @@ module System
   def self.which(program_name)
     (ENV["PATH"] or "").split(":").each do |path|
       full = File.join(path, program_name)
-      if File.exists?(full) && !File.directory?(full) && File.stat(full).executable? then
+      if File.exist?(full) && !File.directory?(full) && File.stat(full).executable? then
         return full
       end
     end
@@ -102,7 +102,7 @@ module System
   # The return format is a hash, with keys being mount point paths,
   # and values being their respective line from /proc/mounts.
   def self.mount_points()
-    unless File.exists?("/.proc/mounts")
+    unless File.exist?("/.proc/mounts")
       $logger.debug("Mounting private procfs at /.proc...")
       FileUtils.mkdir_p("/.proc")
       run("mount", "-t", "proc", "proc", "/.proc")
@@ -203,7 +203,7 @@ module System
   end
 
   def self.cmdline()
-    if File.exists?("/proc/cmdline") then
+    if File.exist?("/proc/cmdline") then
       File.read("/proc/cmdline").split(/\s+/)
     else
       []

--- a/boot/init/tasks/modules.rb
+++ b/boot/init/tasks/modules.rb
@@ -11,7 +11,7 @@ class Tasks::Modules < Task
   end
 
   def run()
-    unless File.exists?(SYS_MODPROBE_PATH)
+    unless File.exist?(SYS_MODPROBE_PATH)
       $logger.warn("Could not tell the path to modprobe to the kernel.")
       $logger.warn("('#{SYS_MODPROBE_PATH}' is missing.)")
       return

--- a/boot/lib/hal/recovery.rb
+++ b/boot/lib/hal/recovery.rb
@@ -22,7 +22,7 @@ module Hal
       # know the intent is to boot the normal system.
       # Is a "boot as recovery" device, and Is `[s_]kip_initramfs` missing?
       if Configuration["device"]["boot_as_recovery"] then
-        if File.exists?("/proc/cmdline") then
+        if File.exist?("/proc/cmdline") then
           !File.read("/proc/cmdline").split(/\s+/).grep(/[s_]kip_initramfs/).any?
         end
       end

--- a/boot/lib/lvgui/lvgl/hacks.rb
+++ b/boot/lib/lvgui/lvgl/hacks.rb
@@ -13,7 +13,7 @@ module LVGL::Hacks
     ]
       .flatten()
       .map { |dir| File.join(dir, assets_path) }
-      .find { |dir| File.exists?(dir) }
+      .find { |dir| File.exist?(dir) }
 
     # Fallback to a probably non-existent dir
     # (So things don't crash too hard)

--- a/doc/_support/devices/generate-devices-listing.rb
+++ b/doc/_support/devices/generate-devices-listing.rb
@@ -180,7 +180,7 @@ $devicesInfo.values.each do |info|
     file.puts("\n\n")
     
     deviceNotesFile = File.join($devicesDir, identifier, "README.adoc")
-    if File.exists?(deviceNotesFile)
+    if File.exist?(deviceNotesFile)
       notes = File.read(deviceNotesFile).split("\n\n", 2).last.strip
       first_line = notes.lines.first.strip
       unless first_line == NOTES_HEADER

--- a/examples/hello/app/windows/device_information.rb
+++ b/examples/hello/app/windows/device_information.rb
@@ -19,10 +19,10 @@ module GUI
     end
 
     def device_info()
-      if File.exists?("/sys/class/dmi/id/product_name")
+      if File.exist?("/sys/class/dmi/id/product_name")
         return "Product Name: #{File.read("/sys/class/dmi/id/product_name").strip}"
       end
-      if File.exists?("/proc/device-tree/model")
+      if File.exist?("/proc/device-tree/model")
         return "DT Model: #{File.read("/proc/device-tree/model").delete("\u0000").strip}"
       end
 
@@ -32,7 +32,7 @@ module GUI
     # Tries to guess at a user-facing CPU name.
     def cpu_name()
       name =
-        if File.exists?("/sys/devices/soc0") then
+        if File.exist?("/sys/devices/soc0") then
           [
             File.read("/sys/devices/soc0/family").strip,
             File.read("/sys/devices/soc0/machine").strip,
@@ -63,7 +63,7 @@ module GUI
     # sys_vendor:QEMU
     def dmi_info()
       dmi_path = "/sys/class/dmi/id"
-      return nil unless File.exists?(dmi_path)
+      return nil unless File.exist?(dmi_path)
       info = [
         "bios_date",
         "bios_release",
@@ -77,7 +77,7 @@ module GUI
         "sys_vendor",
       ].map do |key|
         path = File.join(dmi_path, key)
-        if File.exists?(path) then
+        if File.exist?(path) then
           "  - #{key}: #{File.read(path).strip}"
         else
           nil
@@ -175,7 +175,7 @@ module GUI
       # /sys/devices/soc0/revision:2.1
       # /sys/devices/soc0/serial_number:000000000
       # /sys/devices/soc0/soc_id:321
-      if File.exists?("/sys/devices/soc0") then
+      if File.exist?("/sys/devices/soc0") then
         fields << [
           " - soc0 Family: #{File.read("/sys/devices/soc0/family").strip}",
           " - soc0 Machine: #{File.read("/sys/devices/soc0/machine").strip}",

--- a/examples/installer/app/lib/configuration.rb
+++ b/examples/installer/app/lib/configuration.rb
@@ -8,7 +8,7 @@ module Configuration
     end
 
     def is_uefi()
-      @is_uefi ||= File.exists?("/sys/firmware/efi")
+      @is_uefi ||= File.exist?("/sys/firmware/efi")
       @is_uefi
     end
 
@@ -22,7 +22,7 @@ module Configuration
       end
 
       # Then let's try with the device tree compatible.
-      if File.exists?("/proc/device-tree/compatible") then
+      if File.exist?("/proc/device-tree/compatible") then
         # Let's take the most precise compatible name.
         compatible = File.read("/proc/device-tree/compatible").split("\0").first
 
@@ -49,7 +49,7 @@ module Configuration
 
       # Uh, no device tree? no problem!
       # Let's try and detect the device with its DMI info
-      if File.exists?("/sys/class/dmi/id/product_name")
+      if File.exist?("/sys/class/dmi/id/product_name")
         product_name = File.read("/sys/class/dmi/id/product_name")
         # Bogus example of an UEFI system detection
         #case product_name

--- a/examples/installer/pkgs/scripted-installer/automated-installer.rb
+++ b/examples/installer/pkgs/scripted-installer/automated-installer.rb
@@ -97,7 +97,7 @@ step_marker "Copying channels"
 defexpr = File.join(MOUNT_POINT, "/root/.nix-defexpr")
 FileUtils.mkdir_p(defexpr)
 File.chmod(0700, defexpr)
-unless File.exists?(File.join(defexpr, "/channels")) or File.symlink?(File.join(defexpr, "/channels"))
+unless File.exist?(File.join(defexpr, "/channels")) or File.symlink?(File.join(defexpr, "/channels"))
   File.symlink("/nix/var/nix/profiles/per-user/root/channels", File.join(defexpr, "/channels"))
 end
 

--- a/examples/installer/pkgs/scripted-installer/disk-formatter.rb
+++ b/examples/installer/pkgs/scripted-installer/disk-formatter.rb
@@ -224,7 +224,7 @@ puts "Waiting for target partitions to show up..."
 (1..600).each do |i|
   print "."
   # Assumes they're all present if the last is present
-  break if File.exists?(Helpers::Part.part(disk, partition_count))
+  break if File.exist?(Helpers::Part.part(disk, partition_count))
   sleep(0.1)
 end
 # two dots such that if it's instant we get a proper length ellipsis!


### PR DESCRIPTION
This method was formerly [deprecated](https://ruby-doc.org/core-2.2.0/File.html#exists-3F-method) and is now [removed](https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2) since Ruby 3.2.0.
Replace it with a different method that hopefully does the same thing.

I noticed this while running `bin/kernel-normalize-config` with the default Ruby version in the current Nixpkgs unstable.
I did not really test this besides running `bin/kernel-normalize-config`.