### PR TITLE
modules/initrd: Fix regression after `systemd: 255.6 -> 256.2`

### DIFF
--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -176,6 +176,7 @@ let
 
           # Copy udev.
           copy_bin_and_libs ${udev}/bin/udevadm
+          cp ${lib.getLib udev.kmod}/lib/libkmod.so* $out/lib
           for BIN in ${udev}/lib/udev/*_id; do
             copy_bin_and_libs $BIN
           done


### PR DESCRIPTION
See Nixpkgs d4a80b6d0c51b08cc5692c0f48d554c6ef7f5757

This wouldn't be an issue on a system where kernel modules are not necessary to continue booting.

In my particular situation, block devices for the root fs couldn't be found on my "non-mobile" systems using the Mobile NixOS stage-1.

* * *

Verified on hardware.