### PR TITLE
modules/stage-0: rename removed alias

### DIFF
--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -70,7 +70,7 @@ in
       config = { config, ... }: lib.mkIf supportsStage-0 {
         mobile.boot.stage-1.stage = 0;
         mobile.boot.stage-1.extraUtils = [
-          { package = pkgs.kexectools; }
+          { package = pkgs.kexec-tools; }
           { package = fdt-forward; }
         ];
         mobile.boot.stage-1.bootConfig.stage-0 = {


### PR DESCRIPTION
`kexectools` was renamed to `kexec-tools` in Nixpkgs in https://github.com/NixOS/nixpkgs/commit/3677d4bc22eddac35e5a19080ec09ab387a76528 (Sep 2021). The alias was recently removed in https://github.com/NixOS/nixpkgs/commit/a9e1f4e0abe8f8b5f6b6169323d990a0954280e4.

Without this change, I get an error like this:
```
error: 'kexectools' has been renamed to/replaced by 'kexec-tools'
```

Does Nixpkgs have some flag to disallow aliases so we can find and remove them sooner?