### PR TITLE
pine64-pinephone: kernel 6.11.3 -> 6.11.5

### DIFF
--- a/devices/pine64-pinephone/kernel/config.aarch64
+++ b/devices/pine64-pinephone/kernel/config.aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.11.3 Kernel Configuration
+# Linux/arm64 6.11.5 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-unknown-linux-gnu-gcc (GCC) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/devices/pine64-pinephone/kernel/default.nix
+++ b/devices/pine64-pinephone/kernel/default.nix
@@ -6,14 +6,14 @@
 }:
 
 mobile-nixos.kernel-builder {
-  version = "6.11.3";
+  version = "6.11.5";
   configfile = ./config.aarch64;
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "megi";
     repo = "linux";
-    rev = "orange-pi-6.11-20241010-2301";
-    hash = "sha256-UPUL123v25f7kfTv9XphoaLhF4ExF5kuLOlv3i1D4zY=";
+    rev = "orange-pi-6.11-20241029-1901";
+    hash = "sha256-VEp05hLwVGRH8MLSYd29nTwlhWgH/t9w9yEqBJplr8w=";
   };
   patches = [
     ./0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch


### PR DESCRIPTION
I have been running this on my phone for more than a week without noticing any regressions.