### PR TITLE
Add possibility to produce squashfs rootfses

### DIFF
--- a/boot/init/lib/mounting.rb
+++ b/boot/init/lib/mounting.rb
@@ -12,6 +12,11 @@ module Mounting
           target.add_dependency(:Mount, higher.mount_point)
         end
       end
+      # Add additional dependencies for a mount point.
+      # (See overlayfs usage)
+      target.depends.each do |path|
+        target.add_dependency(:Mount, path)
+      end
     end
   end
 
@@ -28,6 +33,7 @@ module Mounting
         *args,
         type: config["fsType"],
         options: config["options"],
+        depends: config["depends"],
       )
 
       [mount_point, task]
@@ -55,6 +61,7 @@ module Mounting
         mount_point,
         type: config["fsType"],
         options: options,
+        depends: config["depends"],
       )
 
       # TODO: Handle failures gracefully

--- a/boot/init/tasks/mount.rb
+++ b/boot/init/tasks/mount.rb
@@ -92,6 +92,11 @@ module Dependencies
     end
 
     def depends_on?(other)
+      unless task
+        $logger.warn("Missing Mount task for mount point #{@mount_point}")
+        return false
+      end
+
       task.depends_on?(other)
     end
 

--- a/boot/init/tasks/mount.rb
+++ b/boot/init/tasks/mount.rb
@@ -1,5 +1,6 @@
 # Mounts mount point
 class Tasks::Mount < Task
+  attr_reader :depends
   attr_reader :source
   attr_reader :mount_point
 
@@ -26,7 +27,10 @@ class Tasks::Mount < Task
     @registry
   end
 
-  def initialize(source, mount_point=nil, **named)
+  def initialize(source, mount_point=nil, depends: [], **named)
+    @depends = depends.map do |dep|
+      File.join(Tasks::SwitchRoot::SYSTEM_MOUNT_POINT, dep)
+    end
     @named = named
     if mount_point
       @source = source

--- a/boot/init/tasks/mount.rb
+++ b/boot/init/tasks/mount.rb
@@ -13,6 +13,7 @@ class Tasks::Mount < Task
   end
 
   def self.register(mount_point, instance)
+    $logger.debug("Registering Mount task for mount point #{mount_point} #{instance.inspect}")
     mount_point = normalize_mountpoint(mount_point)
     @registry ||= {}
     unless @registry[mount_point].nil? then

--- a/examples/hello-but-squashfs/configuration.nix
+++ b/examples/hello-but-squashfs/configuration.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ../hello/configuration.nix
+  ];
+
+  mobile.rootfs.useSquashfs = true;
+}

--- a/examples/hello-but-squashfs/default.nix
+++ b/examples/hello-but-squashfs/default.nix
@@ -1,0 +1,14 @@
+{ device ? null
+, pkgs ? (import ../../pkgs.nix {})
+}@args':
+let args = args' // { inherit pkgs; }; in
+
+import ../../lib/eval-with-configuration.nix (args // {
+  configuration = [ (import ./configuration.nix) ];
+  additionalHelpInstructions = ''
+    You can build the `-A outputs.default` attribute to build the default output
+    for your device.
+
+     $ nix-build examples/hello-but-squashfs --argstr device ${device} -A outputs.default
+  '';
+})

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -49,6 +49,7 @@
   ./quirks
   ./recovery.nix
   ./rootfs.nix
+  ./rootfs-squashfs.nix
   ./shared-rootfs.nix
   ./stage-0.nix
   ./system-build.nix

--- a/modules/rootfs-squashfs.nix
+++ b/modules/rootfs-squashfs.nix
@@ -1,0 +1,82 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    optionalString
+    types
+  ;
+in
+{
+  options = {
+    mobile = {
+      rootfs = {
+        useSquashfs = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether the rootfs (and system accordingly) will be a squashfs.
+
+            Additional setup is needed with squashfs.
+          '';
+        };
+      };
+    };
+  };
+  config = mkIf (config.mobile.rootfs.useSquashfs) {
+    mobile.generatedFilesystems = {
+      rootfs = lib.mkDefault {
+        filesystem = lib.mkForce "squashfs";                                    
+      };
+    };
+
+    fileSystems = {
+      # Squashfs usage
+      "/" = lib.mkImageMediaOverride {
+        device = "tmpfs";
+        fsType = "tmpfs";
+        neededForBoot = true;
+      };
+      "/nix/.ro-store" = lib.mkImageMediaOverride {
+        autoResize = false;
+        label = lib.mkForce null;
+        fsType = lib.mkForce "squashfs";
+        device = lib.mkForce "/dev/disk/by-partlabel/${config.mobile.generatedFilesystems.rootfs.label}";
+        neededForBoot = true;
+      };
+      "/nix/.rw-store" = lib.mkImageMediaOverride {
+        fsType = "tmpfs";
+        options = [ "mode=0755" ];
+        neededForBoot = true;
+      };
+      "/nix/store" = lib.mkImageMediaOverride {
+        fsType = "overlay";
+        device = "overlay";
+        neededForBoot = true;
+        options = [
+          "lowerdir=/nix/.ro-store/nix/store"
+          "upperdir=/nix/.rw-store/store"
+          "workdir=/nix/.rw-store/work"
+        ];
+        depends = [
+          "/nix/.ro-store"
+          "/nix/.rw-store"
+        ];
+      };
+      # Fishes `nix-path-registration` out of the read-only “rootfs” layer.
+      # This is because the overlayfs mounting is only made for the Nix store.
+      # The only other thing on the FS is this file, and needs to be at the root.
+      "/nix-path-registration" = lib.mkImageMediaOverride {
+        neededForBoot = true;
+        device = "/nix/.ro-store/nix-path-registration";
+        options = [ "bind" ];
+      };
+    };
+
+    mobile.boot.stage-1.kernel.additionalModules = (lib.mkIf config.mobile.boot.stage-1.kernel.modular [
+      "squashfs"
+      "overlay"
+    ]);
+  };
+}

--- a/modules/rootfs.nix
+++ b/modules/rootfs.nix
@@ -48,10 +48,23 @@ in
       ''
         mkdir -p ./nix/store
         echo "Copying system closure..."
+
+        err=0
         while IFS= read -r path; do
           echo "  Copying $path"
-          cp -prf "$path" ./nix/store
+          if test -e "$path"; then
+            cp -prf "$path" ./nix/store
+          else
+            2>&1 printf "ERROR: path %q does not exist...\n" "$path"
+            (( ++err ))
+          fi
         done < "${closureInfo}/store-paths"
+
+        if (( err > 0 )); then
+          2>&1 printf "... Bailing out, %d errors.\n" "$err"
+          exit 2
+        fi
+
         echo "Done copying system closure..."
         cp -v ${closureInfo}/registration ./nix-path-registration
       '';


### PR DESCRIPTION
While it's been rebased out of #761, it's really meant as an additional measure for working around the issues with `make_ext4fs`.

* * *

Most of the work here is within the stage-1 environment, to add useful missing features like support for bind mounts, and overlayfs. Then a bit of declarative goodness is added to make switching to `squashfs` a single option.

NOTE: adding similar options for other filesystems is ***NOT*** needed. With `squashfs` we need to work around the read-only nature of the image.

* * *

### What was done

Checked that `hello` and `hello-but-squashfs` example systems works\*.