### PR TITLE
modules/documentation: Drop workaround for split documentation build

### DIFF
--- a/modules/documentation.nix
+++ b/modules/documentation.nix
@@ -20,7 +20,6 @@ in
     };
   };
   config = {
-    documentation.nixos.options.splitBuild = false;
     mobile.documentation.hydraOutputs = lib.mkAfter [
       # x86_64-linux since we link to the cross-compiled build.
       # TODO: link to native builds?

--- a/modules/luks.nix
+++ b/modules/luks.nix
@@ -4,25 +4,27 @@ let
   inherit (config.boot.initrd) luks;
 in
 
-lib.mkIf (luks.devices != {} || luks.forceLuksSupportInInitrd) {
-  mobile.boot.stage-1 = {
-    bootConfig = {
-      luksDevices = luks.devices;
-    };
-    kernel = {
-      modules = [ "dm_mod" ];
-      additionalModules = [
-        "dm_mod" "dm_crypt" "cryptd" "input_leds"
-      ] ++ luks.cryptoModules
-      ;
-    };
+{
+  config = lib.mkIf (luks.devices != {} || luks.forceLuksSupportInInitrd) {
+    mobile.boot.stage-1 = {
+      bootConfig = {
+        luksDevices = luks.devices;
+      };
+      kernel = {
+        modules = [ "dm_mod" ];
+        additionalModules = [
+          "dm_mod" "dm_crypt" "cryptd" "input_leds"
+        ] ++ luks.cryptoModules
+        ;
+      };
 
-    extraUtils = [
-      { package = pkgs.cryptsetup; }
-      # dmsetup is required for device mapper stuff to work in stage-1.
-      { package = lib.getBin pkgs.lvm2; binaries = [
-        "lvm" "dmsetup"
-      ];}
-    ];
+      extraUtils = [
+        { package = pkgs.cryptsetup; }
+        # dmsetup is required for device mapper stuff to work in stage-1.
+        { package = lib.getBin pkgs.lvm2; binaries = [
+          "lvm" "dmsetup"
+        ];}
+      ];
+    };
   };
 }


### PR DESCRIPTION
This reduces the number of actual no-ops from an unconfigured Mobile NixOS system compared to NixOS.

* * *

The TLDR is that with the split documentation, `meta` is presumed available on the expression coming from a module import, which isn't the case when the expression is, itself, an `mkIf`.