### PR TITLE
Fix evaluating in pure evaluation mode

### DIFF
--- a/bin/hydra-eval
+++ b/bin/hydra-eval
@@ -132,7 +132,7 @@ $cmd += ARGV
 
 # Run the eval
 timer_start = Time.now()
-$stderr.puts " $ hydra-eval-jobs #{$cmd.shelljoin}"
+$stderr.puts " $ hydra-eval-jobs #{$cmd.pretty_shelljoin}"
 out, ret = Open3.capture2({}, "hydra-eval-jobs", *$cmd)
 timer_end = Time.now()
 
@@ -149,7 +149,7 @@ out = $stdout
 out.puts MD.title "Hydra-like evaluation"
 
 out.puts MD.paragraph "Command used to generate this report:"
-out.puts MD.pre " $ " + (["bin/hydra-eval"] + ARGV).shelljoin()
+out.puts MD.pre " $ " + (["bin/hydra-eval"] + ARGV).pretty_shelljoin()
 
 out.puts MD.paragraph "Evaluation took: #{fmt_time(timer_end - timer_start)}"
 

--- a/default.nix
+++ b/default.nix
@@ -1,32 +1,8 @@
-{ device ? null
-, configuration ? null
-, system ? null
-, pkgs ? null
-}@args':
+{ configuration ? null
+, ...
+}@args:
 
-# Do some arguments parsing.
 let
-  system =
-    if args' ? system
-    then (args'.system)
-    else builtins.currentSystem
-  ;
-  pkgs =
-    if args' ? pkgs
-    then
-      if args' ? system
-      then builtins.throw "Providing the `system` argument when providing your own `pkgs` is forbidden. You should instead pass the desired `system` argument to your `pkgs` instance."
-      else (args'.pkgs)
-    else (import ./pkgs.nix { inherit system; })
-  ;
-
-  # Inherit default values correctly in `args`
-  args = builtins.removeAttrs (args' // {
-    inherit pkgs;
-  }) [
-    "system"
-  ];
-
   defaultConfiguration =
     if configuration != null then
       configuration
@@ -46,7 +22,7 @@ import ./lib/eval-with-configuration.nix (args // {
   configuration = [
     defaultConfiguration
   ];
-  additionalHelpInstructions = ''
+  additionalHelpInstructions = { device }: ''
     You can build the `-A outputs.default` attribute to build an empty and
     un-configured image. That image can be configured using `local.nix`.
 

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,31 @@
 { device ? null
 , configuration ? null
-, pkgs ? (import ./pkgs.nix {})
+, system ? null
+, pkgs ? null
 }@args':
 
+# Do some arguments parsing.
 let
+  system =
+    if args' ? system
+    then (args'.system)
+    else builtins.currentSystem
+  ;
+  pkgs =
+    if args' ? pkgs
+    then
+      if args' ? system
+      then builtins.throw "Providing the `system` argument when providing your own `pkgs` is forbidden. You should instead pass the desired `system` argument to your `pkgs` instance."
+      else (args'.pkgs)
+    else (import ./pkgs.nix { inherit system; })
+  ;
+
   # Inherit default values correctly in `args`
-  args = args' // {
+  args = builtins.removeAttrs (args' // {
     inherit pkgs;
-  };
+  }) [
+    "system"
+  ];
 
   defaultConfiguration =
     if configuration != null then

--- a/examples/hello-but-squashfs/default.nix
+++ b/examples/hello-but-squashfs/default.nix
@@ -1,11 +1,9 @@
-{ device ? null
-, pkgs ? (import ../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 import ../../lib/eval-with-configuration.nix (args // {
   configuration = [ (import ./configuration.nix) ];
-  additionalHelpInstructions = ''
+  additionalHelpInstructions = { device }: ''
     You can build the `-A outputs.default` attribute to build the default output
     for your device.
 

--- a/examples/hello/default.nix
+++ b/examples/hello/default.nix
@@ -1,11 +1,9 @@
-{ device ? null
-, pkgs ? (import ../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 import ../../lib/eval-with-configuration.nix (args // {
   configuration = [ (import ./configuration.nix) ];
-  additionalHelpInstructions = ''
+  additionalHelpInstructions = { device }: ''
     You can build the `-A outputs.default` attribute to build the default output
     for your device.
 

--- a/examples/installer/default.nix
+++ b/examples/installer/default.nix
@@ -1,11 +1,9 @@
-{ device ? null
-, pkgs ? (import ../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 import ../../lib/eval-with-configuration.nix (args // {
   configuration = [ (import ./configuration.nix) ];
-  additionalHelpInstructions = ''
+  additionalHelpInstructions = { device }: ''
     The build output to choose depends on the target.
 
     Pinephone, other u-boot, and depthcharge devices: 

--- a/examples/phosh/default.nix
+++ b/examples/phosh/default.nix
@@ -1,11 +1,9 @@
-{ device ? null
-, pkgs ? (import ../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 import ../../lib/eval-with-configuration.nix (args // {
   configuration = [ (import ./configuration.nix) ];
-  additionalHelpInstructions = ''
+  additionalHelpInstructions = { device }: ''
     You can build the `-A outputs.default` attribute to build the default output
     for your device.
 

--- a/examples/plasma-mobile/default.nix
+++ b/examples/plasma-mobile/default.nix
@@ -1,11 +1,9 @@
-{ device ? null
-, pkgs ? (import ../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 import ../../lib/eval-with-configuration.nix (args // {
   configuration = [ (import ./configuration.nix) ];
-  additionalHelpInstructions = ''
+  additionalHelpInstructions = { device }: ''
     You can build the `-A outputs.default` attribute to build the default output
     for your device.
 

--- a/examples/target-disk-mode/default.nix
+++ b/examples/target-disk-mode/default.nix
@@ -1,11 +1,9 @@
-{ device ? null
-, pkgs ? (import ../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 import ../../lib/eval-with-configuration.nix (args // {
   configuration = [ (import ./configuration.nix) ];
-  additionalHelpInstructions = ''
+  additionalHelpInstructions = { device }: ''
     The build output to choose depends on the target.
 
     Pinephone, other u-boot, and depthcharge devices: 

--- a/examples/testing/crash-before-switch-root/default.nix
+++ b/examples/testing/crash-before-switch-root/default.nix
@@ -1,6 +1,5 @@
-{ pkgs ? (import ../../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 let
   system-build = import ../../../lib/eval-with-configuration.nix (args // {

--- a/examples/testing/qemu-cryptsetup/configuration.nix
+++ b/examples/testing/qemu-cryptsetup/configuration.nix
@@ -8,7 +8,10 @@ let
 
   # We are re-using the raw filesystem from the hello system.
   rootfsExt4 = (
-    import ../../hello { device = config.mobile.device.name; }
+    import ../../hello {
+      inherit pkgs;
+      device = config.mobile.device.name;
+    }
   ).config.mobile.generatedFilesystems.rootfs;
 
   # This is not a facility from the disk images builder because **it is really

--- a/examples/testing/qemu-cryptsetup/default.nix
+++ b/examples/testing/qemu-cryptsetup/default.nix
@@ -1,6 +1,5 @@
-{ pkgs ? (import ../../../pkgs.nix {})
-}@args':
-let args = args' // { inherit pkgs; }; in
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 let
   system-build = import ../../../lib/eval-with-configuration.nix (args // {

--- a/lib/eval-with-configuration.nix
+++ b/lib/eval-with-configuration.nix
@@ -11,7 +11,7 @@
 , configuration
   # Internally used to tack on configuration by release.nix
 , additionalConfiguration ? {}
-, additionalHelpInstructions ? ""
+, additionalHelpInstructions ? null
 }:
 if pkgs == null then (builtins.throw "The `pkgs` argument needs to be provided to eval-with-configuration.nix") else
 let
@@ -84,7 +84,7 @@ in
 
     Building this whole set is counter-productive, and not likely to be what
     is desired.
-    ${optionalString (additionalHelpInstructions != "") "\n"}${additionalHelpInstructions}
+    ${optionalString (additionalHelpInstructions != null) "\n"}${additionalHelpInstructions { device = final_device; }}
     *************************************************
     * Please also read your device's documentation. *
     *      It may contain further usage notes.      *

--- a/lib/eval-with-configuration.nix
+++ b/lib/eval-with-configuration.nix
@@ -3,8 +3,12 @@
 # This replaces the previously quite un-hermetic `default.nix` inclusion.
 # This is meant for use internally by Mobile NixOS, the interface here
 # should not be assumed to be *stable*.
-{
-  pkgs ? null
+#
+# This file is also used to provide common in-repository arguments parsing
+# for `system` and `pkgs`.
+#
+{ system ? null
+, pkgs ? null
   # The identifier of the device this should be built for.
   # (This gets massaged later on)
 , device ? null
@@ -12,9 +16,22 @@
   # Internally used to tack on configuration by release.nix
 , additionalConfiguration ? {}
 , additionalHelpInstructions ? null
-}:
-if pkgs == null then (builtins.throw "The `pkgs` argument needs to be provided to eval-with-configuration.nix") else
+}@args':
 let
+  system =
+    if args' ? system
+    then (args'.system)
+    else builtins.currentSystem
+  ;
+  pkgs =
+    if args' ? pkgs
+    then
+      if args' ? system
+      then builtins.throw "Providing the `system` argument when providing your own `pkgs` is forbidden. You should instead pass the desired `system` argument to your `pkgs` instance."
+      else (args'.pkgs)
+    else (import ../pkgs.nix { inherit system; })
+  ;
+
   inherit (pkgs.lib) optionalString strings;
   inherit (strings) concatStringsSep stringAsChars;
 

--- a/lib/release-tools.nix
+++ b/lib/release-tools.nix
@@ -26,6 +26,7 @@ rec {
       ++ (import "${toString pkgs.path}/nixos/modules/module-list.nix")
     )
   }: evalConfig {
+    inherit (pkgs) system;
     inherit baseModules;
     modules =
       (if device ? special

--- a/support/kernel-config/default.nix
+++ b/support/kernel-config/default.nix
@@ -1,10 +1,8 @@
-{ pkgs ? (import ../../pkgs.nix {})
-, device
-}:
+# Ensure CLI passes down arguments
+{ ... }@args:
 
 let
-  eval = import ../../lib/eval-with-configuration.nix ({
-    inherit device pkgs;
+  eval = import ../../lib/eval-with-configuration.nix (args // {
     configuration = [
       (
         { config, lib, ... }:

--- a/support/nix/forbid-builtins.nix
+++ b/support/nix/forbid-builtins.nix
@@ -1,0 +1,48 @@
+# Makes an evaluation somewhat purer, since pure evaluation is inconvenient still...
+# Note that this is not pure regarding inputs, only *purer* with regard to ambient impurities
+
+let
+  import = scopedImport scope';
+  scope' = {
+    inherit import;
+    __currentSystem = scope'.builtins.currentSystem;
+    __currentTime = scope'.builtins.currentTime;
+    __fetchurl = scope'.builtins.fetchurl;
+    __findFile = scope'.builtins.findFile;
+    __nixPath = scope'.builtins.nixPath;
+    builtins = builtins // (builtins.listToAttrs (builtins.map (name: { inherit name; value = builtins.throw "Use of builtins.${name} is forbidden."; }) [
+      "currentSystem"
+      "currentTime"
+      # Forbid any unneeded fetcher outright
+      "fetchGit"
+      "fetchMercurial"
+      "fetchTree"
+      "fetchurl"
+    ])) // {
+      # Ensure angled-bracket syntax use is limited to...
+      nixPath = builtins.throw "Use of __nixPath is forbidden";
+      # ... only providing <nix/fetchurl.nix>.
+      findFile = list: arg:
+        # Poke `nix/fetchurl` path out of our nonsense.
+        if arg == "nix/fetchurl.nix" then <nix/fetchurl.nix> else
+        (builtins.throw "Use of builtins.findFile with argument ${builtins.toJSON arg} is forbidden.")
+      ;
+      # Needed for fetching the pinned Nixpkgs...
+      fetchTarball = args:
+        if builtins.typeOf args != "set"
+        then builtins.throw "Use of builtins.fetchTarball without using the set pattern `{ url, sha256 }` is forbidden."
+        else
+        if (builtins.match "https?://releases.nixos.org/.*nixexprs.tar.xz" args.url) == null
+        then builtins.throw "Use of builtins.fetchTarball in this checking mode is limited to fetching nixexprs from releases.nixos.org. Found ${builtins.toJSON args.url}"
+        else
+        builtins.fetchTarball args
+      ;
+    };
+  };
+in
+
+{path ? ../../default.nix, ...}@args:
+let
+  args' = builtins.removeAttrs args ["path"];
+in
+((import path) args')

--- a/support/nix/pure-eval.sh
+++ b/support/nix/pure-eval.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+#
+# Works around the fact pure evaluation handling outside of Flakes is inconvenient.
+# This ***will*** fill your Nix store with mobile-nixos inputs.
+#
+
+set -e
+PS4=" $ "
+
+this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+
+repo="$this_dir/../.."
+
+export NIX_PATH=""
+
+set -x
+
+CMD=(
+	nix-instantiate
+	--option pure-eval true
+	--expr '{ _repo, path ? "/default.nix", ... }@args: import ("${_repo}/${path}") (builtins.removeAttrs (args) ["_repo" "path"])'
+	--arg _repo "$repo"
+	--argstr path "$path"
+	# Pass through the system, for convenience
+	--arg system "$(nix-instantiate --eval --expr "builtins.currentSystem")"
+	"$@"
+)
+
+exec "${CMD[@]}"


### PR DESCRIPTION
With #712, I ended-up needing to ensure evaluation was as-expected when done in pure evaluation mode. So this started with the tooling to evaluate in pure evaluation mode...

... except that pure evaluation is kind of awful to use outside of Flakes. So I also added another helper that does *unsavoury* things in Nix to work around the fact that pure evaluation ends-up adding the repository to the store for every edit. That helper should not be considered a safe interface to use, and only used as a development help.

```
 $ nix-instantiate support/nix/forbid-builtins.nix --argstr system "x86_64-linux" --arg path ./examples/hello --arg  device ./devices/pine64-pinephone -A outputs.default
```

The "actual" check for pure evaluation should be done with the other helper.

```
 $ support/nix/pure-eval.sh --argstr path "examples/hello" --argstr device "uefi-x86_64" -A outputs.default
```

Note that `bin/hydra-eval` is [now working with pure eval](https://github.com/mobile-nixos/mobile-nixos/blob/595d359518864a13483fd3f4f4ad740cb3bae825/bin/hydra-eval#L103), so that is the *actual proper* check for all intents and purposes. Though it would be better the results were visible on contributions... Something to consider adding to the 

* * *

So after writing tooling to *check* things were proper, and comparing with the existing state before any fixes, I ended-up having to write fixes to understand how and why it was failing in the other PR.

In addition to that, I also ended-up implementing the additional fixes for the example systems. They also needed to be updated.

So the main issue in #712 was how keeping the `pkgs` and `system` coherent is not trivial. It ended-up leading to `builtins.currentSystem` being used even for cross-compilation.

I ended-up further de-duplicating argument handling in the entrypoints. And to prevent `system` to lack coherence with `pkgs`'s `system`, it cannot be passed at the same time. TBF, `system` as an argument here is only needed for pure-evaluation in entrypoints of this repo when also wanting to use the pinned Nixpkgs.

cc @RossComputerGuy