### PR TITLE
overlay: Work around ruby cross-compilation issue

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixos-unstable",
-      "url": "https://releases.nixos.org/nixos/unstable/nixos-25.05beta723344.d3c42f187194/nixexprs.tar.xz",
-      "hash": "0kwwzcza46ygfvrhhbnc7x02z3qw3zkyrjaxcdxmza0jzdv8gydj"
+      "url": "https://releases.nixos.org/nixos/unstable/nixos-25.05beta729683.88195a94f390/nixexprs.tar.xz",
+      "hash": "1q2sjvajlj2wa50smwl6jz0qqzv9hvhy2308zagzw0c3kzbl55c4"
     }
   },
   "version": 3

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -147,4 +147,19 @@ in
     };
 
     image-builder = callPackage ./image-builder {};
- }
+
+} // (super.lib.optionalAttrs (super.stdenv.hostPlatform != super.stdenv.buildPlatform) {
+    #
+    # Nixpkgs cross-compilation workarounds
+    # -------------------------------------
+    #
+
+    ruby_3_3 = super.ruby_3_3.overrideAttrs({
+      # https://github.com/samueldr/nixpkgs/compare/88195a94f390381c6afcdaa933c2f6ff93959cb4...fix/ruby-yjit-cross
+      NIX_RUSTFLAGS = "--target ${super.stdenv.hostPlatform.rust.rustcTargetSpec}";
+    });
+    ruby_3_4 = super.ruby_3_4.overrideAttrs({
+      # https://github.com/samueldr/nixpkgs/compare/88195a94f390381c6afcdaa933c2f6ff93959cb4...fix/ruby-yjit-cross
+      NIX_RUSTFLAGS = "--target ${super.stdenv.hostPlatform.rust.rustcTargetSpec}";
+    });
+ })


### PR DESCRIPTION
See also: https://github.com/samueldr/nixpkgs/compare/88195a94f390381c6afcdaa933c2f6ff93959cb4...fix/ruby-yjit-cross

With the current pinned Nixpkgs, `ruby_3_4` does not build successfully, but updating to `nixos-25.05beta729683.88195a94f390` does, just like it does in the Nixpkgs changes linked.

### What was done

#### For the Ruby fix

Checked that `nix-build --argstr device oneplus-fajita -A pkgs.ruby_3_3 -A pkgs.ruby_3_4` all built.

#### For the update

Checked that `nix-build ./examples/hello --arg device ./support/additional-devices/uefi-x86_64-with-kernel -A outputs.uefi.vm` produces a working system still.

Also note that my personal systems, which include Mobile NixOS, have been udpated to the previous channel bump (634fd4680144). So the big gcc13 → gcc14 update was dogfooded in that way for at least `x86_64`.

> 27/12/2024 12:14:05             3.9 kB         [nixos-25.05beta729082.634fd4680144](https://releases.nixos.org/nixos/unstable/nixos-25.05beta729082.634fd4680144)
> 30/12/2024 02:04:40             3.9 kB         [nixos-25.05beta729683.88195a94f390](https://releases.nixos.org/nixos/unstable/nixos-25.05beta729683.88195a94f390)