### PR TITLE
treewide: rename `hardware.pulseaudio` to `services.pulseaudio`

### DIFF
--- a/devices/pine64-pinephone/sound.nix
+++ b/devices/pine64-pinephone/sound.nix
@@ -13,10 +13,10 @@ in {
     {
       environment.variables.ALSA_CONFIG_UCM2 = ucm2;
     }
-    (lib.mkIf (config.hardware.pulseaudio.enable && !config.hardware.pulseaudio.systemWide) {
+    (lib.mkIf (config.services.pulseaudio.enable && !config.services.pulseaudio.systemWide) {
       systemd.user.services.pulseaudio.environment.ALSA_CONFIG_UCM2 = ucm2;
     })
-    (lib.mkIf (config.hardware.pulseaudio.enable && config.hardware.pulseaudio.systemWide) {
+    (lib.mkIf (config.services.pulseaudio.enable && config.services.pulseaudio.systemWide) {
       systemd.services.pulseaudio.environment.ALSA_CONFIG_UCM2 = ucm2;
     })
   ];

--- a/devices/pine64-pinetab/sound.nix
+++ b/devices/pine64-pinetab/sound.nix
@@ -15,10 +15,10 @@ in {
     {
       environment.variables.ALSA_CONFIG_UCM2 = ucm2;
     }
-    (lib.mkIf (config.hardware.pulseaudio.enable && !config.hardware.pulseaudio.systemWide) {
+    (lib.mkIf (config.services.pulseaudio.enable && !config.services.pulseaudio.systemWide) {
       systemd.user.services.pulseaudio.environment.ALSA_CONFIG_UCM2 = ucm2;
     })
-    (lib.mkIf (config.hardware.pulseaudio.enable && config.hardware.pulseaudio.systemWide) {
+    (lib.mkIf (config.services.pulseaudio.enable && config.services.pulseaudio.systemWide) {
       systemd.services.pulseaudio.environment.ALSA_CONFIG_UCM2 = ucm2;
     })
   ];

--- a/examples/installer/app/lib/configuration.rb
+++ b/examples/installer/app/lib/configuration.rb
@@ -232,7 +232,7 @@ services.pipewire.enable = true;
 hardware.bluetooth.enable = true;
 
 # Bluetooth audio
-hardware.pulseaudio.package = pkgs.pulseaudioFull;
+services.pulseaudio.package = pkgs.pulseaudioFull;
 
 # Enable power management options
 powerManagement.enable = true;

--- a/examples/plasma-mobile/plasma-mobile.nix
+++ b/examples/plasma-mobile/plasma-mobile.nix
@@ -27,7 +27,7 @@
 
   hardware.bluetooth.enable = true;
   services.pipewire.enable = lib.mkDefault true;
-  hardware.pulseaudio.enable = lib.mkDefault false;
+  services.pulseaudio.enable = lib.mkDefault false;
   networking.networkmanager.enable = true;
   networking.wireless.enable = false;
   powerManagement.enable = true;


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/pull/369391