### PR TITLE
LUKS improvements

### DIFF
--- a/boot/lib/hal/recovery.rb
+++ b/boot/lib/hal/recovery.rb
@@ -9,9 +9,10 @@ module Hal
       :KEY_UP,
       :KEY_DOWN,
       # Keys used for "computer" use-cases
+      # do not use lshift or ralt since those may be needed for LUKS password entry
       :KEY_LEFTCTRL,
       :KEY_RIGHTCTRL,
-      :KEY_LEFTSHIFT,
+      :KEY_LEFTALT,
       :KEY_RIGHTSHIFT,
       :KEY_ESC,
     ]

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -225,7 +225,10 @@ class UI
     # Always present, but initially hidden
     @ta.hide(skip_animation: true)
     @ta.instance_exec do
+      # passwords should not be echo'd
       set_pwd_mode(true)
+      set_pwd_show_time(0)
+
       get_style(LVGL::TA_STYLE::BG).dup.tap do |style|
         set_style(LVGL::TA_STYLE::BG, style)
         style.body_main_color = BG_COLOR

--- a/doc/boot_process.adoc
+++ b/doc/boot_process.adoc
@@ -54,7 +54,7 @@ keys are held, it will instead show the recovery menu.
 
 * Volume up
 * Volume down
-* Left shift
+* Left alt
 * Right shift
 * Left control
 * Right control


### PR DESCRIPTION
Two things are changed in this PR:

- the hal layer does not trigger recovery on left shift (which is often used for LUKS entry)
- the LUKS password is no longer echo'd
  - this change is kind of up for debate, because on smartphones I get why it's there, but I still don't think the echo is a great idea
  - ideally someone would implement a "show/hide" button that'd `set_pwd_mode` true/false