### PR TITLE
kernel-builder: Fix ncurses pkg-config workaround

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -601,10 +601,24 @@ stdenv.mkDerivation (inputArgs // {
           # Replace the script with a hardcoded equivalent result.
           # The script echoes values that are sourced (.) in a Makefile.
           cat ${writeShellScript "nconf-cfg.sh" ''
+            set -e
+            set -u
+            set -o pipefail
+
+            cflags=$1
+            libs=$2
+
             export PKG_CONFIG_PATH="${buildPackages.ncurses6.dev}/lib/pkgconfig"
             PKGS="ncursesw menuw panelw"
-            echo cflags=\"$(pkg-config --cflags $PKGS)\"
-            echo libs=\"-L $(pkg-config --variable=libdir ncursesw) $(pkg-config --libs $PKGS)\"
+
+            (
+            pkg-config --cflags $PKGS
+            ) > "$cflags"
+
+            (
+            printf -- "-L%s\n" $(pkg-config --variable=libdir $PKGS)
+            pkg-config --libs $PKGS
+            ) > "$libs"
           ''} > scripts/kconfig/nconf-cfg.sh
         fi
 


### PR DESCRIPTION
I don't get how it was ever working...

The script needs to write to passed paths...

Fixes #751.