### PR TITLE
unbound: fix cross-compiling issue with yacc

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixos-unstable",
-      "url": "https://releases.nixos.org/nixos/unstable/nixos-25.05beta723344.d3c42f187194/nixexprs.tar.xz",
-      "hash": "0kwwzcza46ygfvrhhbnc7x02z3qw3zkyrjaxcdxmza0jzdv8gydj"
+      "url": "https://releases.nixos.org/nixos/unstable/nixos-25.05beta729683.88195a94f390/nixexprs.tar.xz",
+      "hash": "1q2sjvajlj2wa50smwl6jz0qqzv9hvhy2308zagzw0c3kzbl55c4"
     }
   },
   "version": 3

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -147,4 +147,19 @@ in
     };
 
     image-builder = callPackage ./image-builder {};
- }
+
+} // (super.lib.optionalAttrs (super.stdenv.hostPlatform != super.stdenv.buildPlatform) {
+    #
+    # Nixpkgs cross-compilation workarounds
+    # -------------------------------------
+    #
+
+    ruby_3_3 = super.ruby_3_3.overrideAttrs({
+      # https://github.com/samueldr/nixpkgs/compare/88195a94f390381c6afcdaa933c2f6ff93959cb4...fix/ruby-yjit-cross
+      NIX_RUSTFLAGS = "--target ${super.stdenv.hostPlatform.rust.rustcTargetSpec}";
+    });
+    ruby_3_4 = super.ruby_3_4.overrideAttrs({
+      # https://github.com/samueldr/nixpkgs/compare/88195a94f390381c6afcdaa933c2f6ff93959cb4...fix/ruby-yjit-cross
+      NIX_RUSTFLAGS = "--target ${super.stdenv.hostPlatform.rust.rustcTargetSpec}";
+    });
+ })

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -162,4 +162,13 @@ in
       # https://github.com/samueldr/nixpkgs/compare/88195a94f390381c6afcdaa933c2f6ff93959cb4...fix/ruby-yjit-cross
       NIX_RUSTFLAGS = "--target ${super.stdenv.hostPlatform.rust.rustcTargetSpec}";
     });
+
+    unbound = super.unbound.overrideAttrs (old: {
+      # https://github.com/NixOS/nixpkgs/commit/a36d820bab68e43bf841e45ed168dc6f38bdf83c
+      nativeBuildInputs = old.nativeBuildInputs ++ [
+        super.bison
+        super.flex
+        super.pkg-config
+      ];
+    });
  })


### PR DESCRIPTION
Based on https://github.com/mobile-nixos/mobile-nixos/pull/771 , which has fixes for ruby, which also does overlays. In theory might not be needed, but seemed nice to do.

Closes #785 