### PR TITLE
Fix ImageMagick warning

### DIFF
--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -171,7 +171,7 @@ in
             perl # Needed by netpbm
           ];
         } ''
-          convert \
+          magick \
             ${cfg.logo.logo} \
             -resize ${toString config.mobile.hardware.screen.width}x${toString config.mobile.hardware.screen.height} \
             -trim converted.ppm


### PR DESCRIPTION
Fixes the following warning:
```
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"
```

I saw this warning while executing the `bin/kernel-normalize-all` script.