### PR TITLE
CI: update Ruby and Python versions

### DIFF
--- a/bin/hydra-eval
+++ b/bin/hydra-eval
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p ruby -i ruby
+#!nix-shell -p ruby_3_3 -i ruby
 #!nix-shell -p hydra
 
 # This script uses hydra's `hydra-eval-jobs` to evaluate a given expression,
@@ -34,7 +34,7 @@ def fmt_time(seconds)
     if current != 0
       elements.unshift("%d %s" % [ current, name ])
     end
-    
+
     [leftover, elements]
   end.last().join(", ")
 end

--- a/boot/init/default.nix
+++ b/boot/init/default.nix
@@ -8,11 +8,11 @@
 }:
 
 let
-  ruby_rev = "37457117c941b700b150d76879318c429599d83f";
+  ruby_rev = "d0b7e5b6a04bde21ca483d20a1546b28b401c2d4";
   shellwords = fetchurl {
     name = "shellwords.rb";
     url = "https://raw.githubusercontent.com/ruby/ruby/${ruby_rev}/lib/shellwords.rb";
-    sha256 = "197g7qvrrijmajixa2h9c4jw26l36y8ig6qjb5d43qg4qykhqfcx";
+    sha256 = "14ll9q3pgykv2fs8mxx2kzz1r9x4n03dlxi6nsfwvzic2dmy364h";
   };
 
   inherit (lib) concatMapStringsSep;

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -7,9 +7,9 @@ let
   # Static libraries (.a) aren't available in the "lib" package.
   # libtool, reading the `.la` files in the "lib" package expects `.a`
   # to be in the "lib" package; they are in out.
-  merged_gcc7 = super.wrapCC (self.symlinkJoin {
-    name = "gcc7-merged";
-    paths = with super.buildPackages.gcc7.cc; [ out lib ];
+  merged_gcc10 = super.wrapCC (self.symlinkJoin {
+    name = "gcc10-merged";
+    paths = with super.buildPackages.gcc10.cc; [ out lib ];
   });
 in
   {
@@ -24,7 +24,7 @@ in
       stdenv = if self.buildPlatform != self.targetPlatform then
         self.stdenv
       else
-        with self; overrideCC stdenv (merged_gcc7)
+        with self; overrideCC stdenv (merged_gcc10)
       ;
     };
     mkbootimg = callPackage ./mkbootimg { };

--- a/overlay/ufdt-apply-overlay/default.nix
+++ b/overlay/ufdt-apply-overlay/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, dtc, python }:
+{ stdenv, lib, fetchFromGitHub, dtc, python3 }:
 
 stdenv.mkDerivation {
   pname = "ufdt-apply-overlay";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     dtc
-    python
+    python3
   ];
 
   postPatch = ''


### PR DESCRIPTION
Deprecated versions of Ruby and Python are causing evaluations to fail.

Versions were chosen purely because they were most recent and I could get them to work. There may be good reasons to use other versions.