### PR TITLE
examples/installer: use Squashfs

### DIFF
--- a/examples/installer/configuration.nix
+++ b/examples/installer/configuration.nix
@@ -11,4 +11,6 @@
   imports = [
     ./modules/all.nix
   ];
+
+  mobile.rootfs.useSquashfs = true;
 }


### PR DESCRIPTION
ext4 image generation is currently broken, so this allows building the installer again.

Fixes #796.

The installer still fails according to https://github.com/mobile-nixos/mobile-nixos/issues/796#issuecomment-2869118476 but at least we can build the installer image again.