### PR TITLE
libhybris: Drop "merged GCC" hack

### DIFF
--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -2,15 +2,6 @@ self: super:
 
 let
   callPackage = self.callPackage;
-  # FIXME : upstream fix for .a in "lib" instead of this hack.
-  # This is used to "re-merge" the split gcc package.
-  # Static libraries (.a) aren't available in the "lib" package.
-  # libtool, reading the `.la` files in the "lib" package expects `.a`
-  # to be in the "lib" package; they are in out.
-  merged_gcc7 = super.wrapCC (self.symlinkJoin {
-    name = "gcc7-merged";
-    paths = with super.buildPackages.gcc7.cc; [ out lib ];
-  });
 in
   {
     # Misc. tools.
@@ -19,14 +10,7 @@ in
     android-headers = callPackage ./android-headers { };
     dtbTool = callPackage ./dtbtool { };
     dtbTool-exynos = callPackage ./dtbtool-exynos { };
-    libhybris = callPackage ./libhybris {
-      # FIXME : verify how it acts on native aarch64 build.
-      stdenv = if self.buildPlatform != self.targetPlatform then
-        self.stdenv
-      else
-        with self; overrideCC stdenv (merged_gcc7)
-      ;
-    };
+    libhybris = callPackage ./libhybris { };
     mkbootimg = callPackage ./mkbootimg { };
     msm-fb-refresher = callPackage ./msm-fb-refresher { };
     ply-image = callPackage ./ply-image { };


### PR DESCRIPTION
Let's finally merge this commit.
You wrote: "I cannot recall what I meant 6.5 years ago. It is a mystery to you and I."

A friend of mine is trying to build the PinePhone installer and this hack is preventing him from doing so:
```
$ nix-build examples/installer --argstr device pine64-pinephone -A outputs.default --system aarch64-linux
error: gcc7 has been removed from Nixpkgs, as it is unmaintained and obsolete
```