### PR TITLE
pine64-pinephone(pro): Fix "fatal: unable to update url base from redirection"

### DIFF
--- a/devices/pine64-pinephone/firmware/default.nix
+++ b/devices/pine64-pinephone/firmware/default.nix
@@ -6,7 +6,7 @@
 # The minimum set of firmware files required for the device.
 runCommand "pine64-pinephone-firmware" {
   src = fetchgit {
-    url = "https://megous.com/git/linux-firmware";
+    url = "https://xff.cz/git/linux-firmware";
     rev = "6e8e591e17e207644dfe747e51026967bb1edab5";
     hash = "sha256-TaGwT0XvbxrfqEzUAdg18Yxr32oS+RffN+yzSXebtac=";
   };

--- a/devices/pine64-pinephonepro/firmware/default.nix
+++ b/devices/pine64-pinephonepro/firmware/default.nix
@@ -21,7 +21,7 @@ let
     sha256 = "sha256-i2OEkn7RtEMbJd0sYEE2Hpkvw6KRppz5AbwXJFNa/pE=";
   };
   brcm-firmware = fetchgit {
-    url = "https://megous.com/git/linux-firmware";
+    url = "https://xff.cz/git/linux-firmware";
     rev = "6e8e591e17e207644dfe747e51026967bb1edab5";
     sha256 = "sha256-TaGwT0XvbxrfqEzUAdg18Yxr32oS+RffN+yzSXebtac=";
   };


### PR DESCRIPTION
Without this, the firmware cannot be downloaded:
```
fatal: unable to update url base from redirection:
  asked for: https://megous.com/git/linux-firmware/info/refs?service=git-upload-pack
   redirect: https://xff.cz/git/linux-firmware/info/refs
Unable to checkout 0510074346983ad33b3d52ce8f5d6a8f89a564a8 from https://megous.com/git/linux-firmware.
```