### PR TITLE
adbd: Fix build with recent changes

### DIFF
--- a/overlay/adbd/default.nix
+++ b/overlay/adbd/default.nix
@@ -48,4 +48,9 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     cp -v core/build_adbd/adbd $out/bin/
   '';
+
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-implicit-function-declaration"
+    "-Wno-incompatible-pointer-types"
+  ];
 }

--- a/overlay/libhybris/default.nix
+++ b/overlay/libhybris/default.nix
@@ -37,6 +37,14 @@ stdenv.mkDerivation {
       --replace "/usr/bin/file" "${file}/bin/file"
   '';
 
+  NIX_CFLAGS_COMPILE = [
+    # This libhybris is old, but even libhybris from 2024 fails to compile
+    # due to many warnings. Let's instead ignore the warnings, and instead
+    # plan to get an updated adbd that maybe does not depend on libhybris.
+    "-Wno-implicit-function-declaration"
+    "-Wno-incompatible-pointer-types"
+    "-Wno-int-conversion"
+  ];
   NIX_LDFLAGS = [
     # For libsupc++.a
     "-L${stdenv.cc.cc.out}/${libPrefix}/lib/"


### PR DESCRIPTION
TLDR is that libhybris still would require workarounds or fixes. So instead let's shovel forward the need to fix that.

Ideally we'd have an adbd that works without libhybris instead. And prioritize updating adbd.