### PR TITLE
modules/system-target: Update with modern NixOS/Nixpkgs semantics

### DIFF
--- a/modules/hardware-soc.nix
+++ b/modules/hardware-soc.nix
@@ -26,7 +26,7 @@ in
     # Otherwise we want to error on an unset value if not set.
     mobile.hardware.soc = mkIf (!config.mobile.enable) (
       mkOptionDefault (
-        "generic-${config.nixpkgs.localSystem.parsed.cpu.name}"
+        "generic-${config.nixpkgs.hostPlatform.parsed.cpu.name}"
       )
     );
   };

--- a/modules/system-target.nix
+++ b/modules/system-target.nix
@@ -2,28 +2,55 @@
 
 let
   inherit (lib)
+    mkDefault
+    mkIf
     mkOption
     types
   ;
+  inherit (lib.systems)
+    elaborate
+  ;
+  inherit (config)
+    nixpkgs
+  ;
+  inherit (config.nixpkgs)
+    hostPlatform
+    localSystem
+  ;
   cfg = config.mobile.system;
-  inherit (config.nixpkgs) localSystem;
 
-  # The platform selected by the configuration
-  selectedPlatform = lib.systems.elaborate cfg.system;
+  # Use JSON to escape values for printing
+  e = builtins.toJSON;
 
-  isCross = selectedPlatform.system != localSystem.system;
+  # When `nixpkgs` is built on a different platform than it will be running on.
+  isCross = deviceHostPlatform.system != localSystem.system;
+
+  # The host platform selected by the Mobile device configuration
+  deviceHostPlatform = elaborate cfg.system;
+
+  # Be mindful about using `config` values that depends on `nixpkgs.buildPlatform`!
+  # This is used when setting `nixpkgs.buildPlatform`, so any values depending on `nixpkgs.buildPlatform`,
+  # including `nixpkgs.buildPlatform` will cause an infinite recursion.
+  traceCrossBuildPlatform =
+    buildPlatform:
+    builtins.trace ''
+      Building for cross?: ${e deviceHostPlatform.system} != ${e localSystem.system} → ${if isCross then "we are" else "we're not"}.
+                nixpkgs.buildPlatform.config → ${e /*nixpkgs.*/buildPlatform.config}
+                nixpkgs.hostPlatform.config → ${e nixpkgs.hostPlatform.config}
+    '' buildPlatform
+  ;
 in
 {
   options.mobile = {
     system.system = mkOption {
-      # Known supported target types for Mobile NixOS
+      # Known supported target types.
       type = types.enum [
         "aarch64-linux"
         "armv7l-linux"
         "x86_64-linux"
       ];
       description = ''
-        Defines the kind of target architecture system the device is.
+        Defines the host platform architecture the device is.
 
         This will automagically setup cross-compilation where possible.
       '';
@@ -34,15 +61,19 @@ in
     assertions = [
       {
         assertion = pkgs.stdenv.targetPlatform.system == cfg.system;
-        message = "pkgs.stdenv.targetPlatform.system expected to be `${cfg.system}`, is `${pkgs.stdenv.targetPlatform.system}`";
+        message = "pkgs.stdenv.targetPlatform.system expected to be ${e cfg.system}, is ${e pkgs.stdenv.targetPlatform.system}";
       }
     ];
 
-    nixpkgs.crossSystem = lib.mkIf isCross (
-      builtins.trace ''
-        Building with crossSystem?: ${selectedPlatform.system} != ${localSystem.system} → ${if isCross then "we are" else "we're not"}.
-               crossSystem: config: ${selectedPlatform.config}''
-      selectedPlatform
-    );
+    nixpkgs.hostPlatform =
+      mkDefault deviceHostPlatform
+    ;
+    nixpkgs.buildPlatform =
+      mkIf isCross (
+        # We are only using `traceCrossBuildPlatform` when doing cross-compilation.
+        # Otherwise it's noise for native builds.
+        mkDefault (traceCrossBuildPlatform (elaborate localSystem.system))
+      )
+    ;
   };
 }

--- a/modules/system-target.nix
+++ b/modules/system-target.nix
@@ -60,8 +60,12 @@ in
   config = {
     assertions = [
       {
-        assertion = pkgs.stdenv.targetPlatform.system == cfg.system;
-        message = "pkgs.stdenv.targetPlatform.system expected to be ${e cfg.system}, is ${e pkgs.stdenv.targetPlatform.system}";
+        assertion = cfg.system == pkgs.stdenv.targetPlatform.system;
+        message = ''
+          pkgs.stdenv.targetPlatform.system expected to be ${e cfg.system}, is ${e pkgs.stdenv.targetPlatform.system}
+              nixpkgs.buildPlatform → ${e config.nixpkgs.buildPlatform.system}
+              nixpkgs.hostPlatform → ${e config.nixpkgs.hostPlatform.system}
+        '';
       }
     ];
 


### PR DESCRIPTION
It's been a while since I authored this module, and things have changed.

This fixes an issue where an assertion triggers due to setting the legacy `crossSystem` option. And the assertion (needlessly) checks the definition's priority to trigger.

So even forcing the original default value will fail!

In turn, this means that configurations attempting to handle cross for the Mobile configuration cannot compose due to the NixOS assertion.

* * *

This also fixes a bug where `generic-*` SoCs would apply wrongly when using the *Mobile modules* without evaluating a device.