### PR TITLE
Drop usage of bespoke `composeConfig`

### DIFF
--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -1,38 +1,20 @@
-parentArgs@{ config, lib, pkgs, baseModules, modules, ... }:
+{ lib, extendModules, ... }:
 
-let
-  # Keep modules from this eval around
-  modules' = modules;
-
-  inherit (config.nixpkgs.localSystem) system;
-
-  # We can make use the normal NixOS evalConfig here.
-  evalConfig = import "${toString pkgs.path}/nixos/lib/eval-config.nix";
-in
 {
   lib = {
     mobile-nixos = {
-      # `config.lib.mobile-nixos.composeConfig` is the supported method used to
-      # re-evaluate a configuration with additional configuration.
-      # Can be used exactly like `evalConfig`, with one additional param.
-      # The `config` param directly takes a module (attrset or function).
-      composeConfig = { config ? {}, modules ? [], ... }@args:
-      let
-        filteredArgs = lib.filterAttrs (k: v: k != "config") args;
-      in
-      evalConfig (
-        filteredArgs // {
-        # Needed for hermetic eval, otherwise `eval-config.nix` will try
-        # to use `builtins.currentSystem`.
-        inherit system;
-        inherit baseModules;
-        # Newer versions of module system pass specialArgs to modules, so try
-        # to pass that to eval if possible.
-        specialArgs = parentArgs.specialArgs or { };
-        # Merge in this eval's modules with the argument's modules, and finally
-        # with the given config.
-        modules = modules' ++ modules ++ [ config ];
-      });
+      # This was the previously supported method used to re-evaluate a
+      # configuration with additional configuration.
+      composeConfig = { config ? {}, modules ? [] }:
+        builtins.trace "warning: Please migrate from `composeConfig` to `extendModules`. The latter is the proper way to extend a configuration using the modules system."(
+          extendModules {
+            modules = [
+              { isSpecialisation = lib.mkDefault true; }
+              config
+            ];
+          }
+        )
+      ;
     };
   };
 }

--- a/modules/recovery.nix
+++ b/modules/recovery.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, extendModules, ... }:
 
 # This module provides the `recovery` build output.
 # It is the same configuration, with minor customizations.
@@ -23,13 +23,15 @@ in
   };
 
   config = {
-      mobile.outputs.recovery = (config.lib.mobile-nixos.composeConfig {
-      config = {
-        mobile.system.android.bootimg.name = "recovery.img";
-        mobile.boot.stage-1.bootConfig = {
-          is_recovery = true;
-        };
-      };
+    mobile.outputs.recovery = (extendModules {
+      modules = [
+        {
+          mobile.system.android.bootimg.name = "recovery.img";
+          mobile.boot.stage-1.bootConfig = {
+            is_recovery = true;
+          };
+        }
+      ];
     }).config;
   };
 }

--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, extendModules, ... }:
 
 # This module provides the `stage-0` build output.
 # It is the same configuration, with minor customizations.
@@ -66,24 +66,29 @@ in
   };
 
   config = {
-    mobile.outputs.stage-0 = (config.lib.mobile-nixos.composeConfig {
-      config = { config, ... }: lib.mkIf supportsStage-0 {
-        mobile.boot.stage-1.stage = 0;
-        mobile.boot.stage-1.extraUtils = [
-          { package = pkgs.kexec-tools; }
-          { package = fdt-forward; }
-        ];
-        mobile.boot.stage-1.bootConfig.stage-0 = {
-          forward = {
-            nodes = [
-              "/memory"
-            ] ++ config.mobile.quirks.fdt-forward.nodes;
-            props = [
-              ["/" "serial-number"]
-            ] ++ config.mobile.quirks.fdt-forward.props;
-          };
-        };
-      };
+    mobile.outputs.stage-0 = (extendModules {
+      modules = [
+        (
+          { config, ... }:
+          lib.mkIf supportsStage-0 {
+            mobile.boot.stage-1.stage = 0;
+            mobile.boot.stage-1.extraUtils = [
+              { package = pkgs.kexec-tools; }
+              { package = fdt-forward; }
+            ];
+            mobile.boot.stage-1.bootConfig.stage-0 = {
+              forward = {
+                nodes = [
+                  "/memory"
+                ] ++ config.mobile.quirks.fdt-forward.nodes;
+                props = [
+                  ["/" "serial-number"]
+                ] ++ config.mobile.quirks.fdt-forward.props;
+              };
+            };
+          }
+        )
+      ];
     }).config;
   };
 }

--- a/modules/system-types/uefi/vm.nix
+++ b/modules/system-types/uefi/vm.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, extendModules, ... }:
 
 let
   inherit (lib) mkIf mkMerge mkOption types;
@@ -18,7 +18,7 @@ in
         internal = true;
         description = ''
           Internal switch to select whether the `outputs.uefi.vm` value points
-          to the composeConfig usage, or to the actual output.
+          to the VM config, or to the actual output.
         '';
       };
       outputs = {
@@ -81,10 +81,12 @@ in
       };
     })
     (mkIf (!config.mobile.quirks.uefi.enableVM) {
-      mobile.outputs.uefi.vm = (config.lib.mobile-nixos.composeConfig {
-        config = {
-          mobile.quirks.uefi.enableVM = true;
-        };
+      mobile.outputs.uefi.vm = (extendModules {
+        modules = [
+          {
+            mobile.quirks.uefi.enableVM = true;
+          }
+        ];
       }).config.mobile.outputs.uefi.vm;
     })
   ];


### PR DESCRIPTION
Instead, let's use the upstream-provided `extendModules`.

Don't forget to look at just how old this module was:

 - https://github.com/mobile-nixos/mobile-nixos/commits/development/modules/lib.nix

:see_no_evil: 

Using `extendModules` basically re-uses the semantics that `specialisation` uses. So it should keep in-line with the assumptions upstream makes regarding the configuration and how it *composes* together.

I'm still keeping `composeConfig` (the function) around at the moment because it was technically part of a semi-public API. It's probably getting removed at some point, but it's not hurting to keep it for now.

* * *

What was done:

 - Verified evaluations previously using `composeConfig` evaluate to the same `drvs`. (i.e. a big no-op change.)
   - `nix-instantiate ./. --arg device  ./devices/uefi-x86_64 --attr outputs.uefi.vm`

* * *

Fixes #820, cc @Luflosi to confirm.

At least, I'm pretty sure it should, since it's not very rudely setting "all options to the values set in the parent config"...