### PR TITLE
kernel/builder: Remove dangling symlink

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -484,6 +484,10 @@ stdenv.mkDerivation (inputArgs // {
     # Helpful in cases where the kernel isn't built with /proc/config.gz
     cp -v "$buildRoot/.config" "$out/build.config"
 
+    # Clean up potential broken symlinks
+    rm -vf "$out/lib/modules/${modDirVersion}/build"
+    rm -vf "$out/lib/modules/${modDirVersion}/source"
+
   '' + optionalString hasDTB ''
     echo ":: Installing DTBs"
     mkdir -p $out/dtbs/


### PR DESCRIPTION
Fixes the following error when compiling a kernel with the latest Nixpkgs:
```
ERROR: noBrokenSymlinks: the symlink /nix/store/3a842gfl010rpfvr8mh2agig04pmbjvv-linux-6.13.8/lib/modules/6.13.8/build points to /build directory: /build/source/build
ERROR: noBrokenSymlinks: found 1 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
```

Please check that I added this line in the correct place.