### PR TITLE
bin/normalize-config: add option to pass extra flags to nix commands

### DIFF
--- a/bin/kernel-normalize-config
+++ b/bin/kernel-normalize-config
@@ -57,7 +57,7 @@ ALSO_COMMIT =
 
 DEVICE = other_args.shift
 
-args =
+nix_args =
   # Is the device a path?
   if DEVICE.match(%r{/})
     ["--arg", "device", DEVICE.sub(%r{/+$}, "")]
@@ -66,7 +66,7 @@ args =
   end
 
 # 
-args << File.join(ROOT, "support/kernel-config/default.nix")
+nix_args << File.join(ROOT, "support/kernel-config/default.nix")
 
 @file =
   if params["file"]
@@ -92,7 +92,7 @@ unless ONLY_CHECK
       `#{[
         "nix-instantiate",
         "--eval",
-        *args,
+        *nix_args,
         "--attr", "config.mobile.boot.stage-1.kernel.package.configfile",
       ].shelljoin}`.strip
   end
@@ -124,7 +124,7 @@ attr =
 result = `#{[
   "nix-build",
   "--no-out-link",
-  *args,
+  *nix_args,
   "-A", attr
 ].shelljoin}`.strip
 

--- a/bin/kernel-normalize-config
+++ b/bin/kernel-normalize-config
@@ -13,7 +13,7 @@ require "shellwords"
 ROOT = File.join(__dir__, "..")
 
 def usage()
-  puts "Usage: bin/kernel-normalize-config [--file=config.path] --only-check <device_name>"
+  puts "Usage: bin/kernel-normalize-config [--file=config.path] --only-check <device_name> [-- <nix_args>...]"
   puts ""
   puts " --file=path/to/kernel/config.file -- detected automatically if not present."
   puts " --only-check"
@@ -23,7 +23,10 @@ end
 FAMILIES_DIR = File.absolute_path(File.join(__dir__(), "..", "/devices/families/"))
 
 # Poor approximation to arguments parsing.
-params, other_args = ARGV.partition { |s| s.match(/^--/) }
+arg_chunks = ARGV.slice_before("--")
+args = arg_chunks.first || []
+extra_nix_args = arg_chunks.drop(1).flatten.drop(1)
+params, other_args = args.partition { |s| s.match(/^--/) }
 
 if other_args.empty?
   $stderr.puts "Device name required."
@@ -67,6 +70,7 @@ nix_args =
 
 # 
 nix_args << File.join(ROOT, "support/kernel-config/default.nix")
+nix_args += extra_nix_args
 
 @file =
   if params["file"]


### PR DESCRIPTION
I like to pass `--builders ""` sometimes, to avoid having to copy a large src tree to a remote builder when the actual derivation builds quickly.

I'm not very familiar with ruby, feel free to let me know if there's a better way to do this.