### PR TITLE
stage-1: Fix physical keyboard input regression (and crash)

### DIFF
--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -7,6 +7,8 @@
 , SDL2
 , libdrm
 , libevdev
+, libinput
+, libxkbcommon
 , withSimulator ? false
 }:
 
@@ -15,76 +17,6 @@ let
   simulatorDeps = [
     SDL2
   ];
-
-  # Minified libinput, both for size and cross-compilation.
-  libinput = (pkgs.libinput.override({
-    # libwacom doesn't cross-compile at the moment
-    libwacom = null;
-
-    documentationSupport = false;
-    doxygen = null;
-    graphviz = null;
-
-    eventGUISupport = false;
-    cairo = null;
-    glib = null;
-    gtk3 = null;
-
-    testsSupport = false;
-    check = null;
-    valgrind = null;
-    python3 = null;
-  })).overrideAttrs(old: {
-    buildInputs = with pkgs; [
-      libevdev
-      mtdev
-    ];
-    nativeBuildInputs = old.nativeBuildInputs ++ [
-      pkgs.buildPackages.udev
-    ];
-    mesonFlags = old.mesonFlags ++ [
-      "-Dlibwacom=false"
-    ];
-  });
-
-  libxkbcommon = pkgs.callPackage (
-    { stdenv
-    , libxkbcommon
-    , meson
-    , ninja
-    , pkg-config
-    , bison
-    }:
-
-    libxkbcommon.overrideAttrs({...}: {
-      nativeBuildInputs = [ meson ninja pkg-config bison ];
-      buildInputs = [ ];
-
-      mesonFlags = [
-        "-Denable-wayland=false"
-        "-Denable-x11=false"
-        "-Denable-docs=false"
-        "-Denable-xkbregistry=false"
-
-        # This is because we're forcing uses of this build
-        # to define config and locale root; for stage-1 use.
-        # In stage-2, use the regular xkbcommon lib.
-        "-Dxkb-config-root=/NEEDS/OVERRIDE/etc/X11/xkb"
-        "-Dx-locale-root=/NEEDS/OVERRIDE/share/X11/locale"
-      ];
-
-      outputs = [ "out" "dev" ];
-
-      # Ensures we don't get any stray dependencies.
-      allowedReferences = [
-        "out"
-        "dev"
-        stdenv.cc.libc_lib
-      ];
-    })
-
-  ) {};
-
 in
   stdenv.mkDerivation {
     pname = "lvgui";

--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -20,13 +20,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2024-03-29";
+    version = "2025-08-02";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "8768bab377a7ccab0b25b96d204af670820f8c76";
-      hash = "sha256-lDmUppndyDGY1EJT7FC6Fdb3AT2M6D75FnXw4bPNrD0=";
+      rev = "3c8db713ab89707dc490929e94f20c143ed5b7fc";
+      hash = "sha256-0j2cRLfcGPUwPmSO2EQQDN4K9TnRypu+SM6Yy02yjdw=";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -14,9 +14,9 @@ let
     allowedReferences = [ "out" ];
   } ''
     (PS4=" $ "; set -x
-    mkdir -p $out
-    cp -r ${pkgs.xorg.xkeyboardconfig}/share/X11/xkb $out/xkb
-    cp -r ${pkgs.xorg.libX11.out}/share/X11/locale $out/locale
+    mkdir -vp "$out/xkb"
+    cp -vr -t "$out/xkb/" ${pkgs.xorg.xkeyboardconfig}/share/X11/xkb/*
+    cp -vr ${pkgs.xorg.libX11.out}/share/X11/locale $out/locale
     )
 
     for f in $(grep -lIiR '${pkgs.xorg.libX11.out}' $out); do

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixos-unstable",
-      "url": "https://releases.nixos.org/nixos/unstable/nixos-25.11pre804993.063f43f2dbde/nixexprs.tar.xz",
-      "hash": "0hly1w4dwmj2i017966jy97mmffkcx4a802h8dibs3w727pgwvfx"
+      "url": "https://releases.nixos.org/nixos/unstable/nixos-25.11pre833752.fc02ee70efb8/nixexprs.tar.xz",
+      "hash": "13djcw3j6mybs22ciimrfwfyhgy3wqr462jvw8z7rzk90wj9k94h"
     }
   },
   "version": 5


### PR DESCRIPTION
This fixes a regression coming from the `xkeyboard` package upgrade, where the config files were moved about, and now we had no config files anymore.

This also fixes an issue where it was *possible* (always?) that physical keyboard input may not work in stage-2 with the LVGUI applets.

And finally, fixes a long-standing crash with modifier keys and fumbling around with other keys. I ended-up noticing that CTRL+A was a good crasher.

* * *

### What was done

 - Tested with the QEMU VM
 - Verified good on my machine where I observed the issue



* * *

cc @benaryorg, who had noticed in #776 the underlying issue this fixes with physical keyboard input crashes.