### PR TITLE
boot/splash: Fix metrics of the passphrase input (BGRT)

### DIFF
--- a/boot/lib/lvgui/lvgui/keyboard.rb
+++ b/boot/lib/lvgui/lvgui/keyboard.rb
@@ -4,12 +4,14 @@
 class LVGUI::Keyboard < LVGUI::Widget
   include Singleton
 
+  attr_accessor :animation_duration
   attr_accessor :container
 
   private
 
   def initialize()
     @shown = false
+    @animation_duration = 300
     # Attach the keyboard to the current active screen, by default.
     super(LVGL::LVKeyboard.new(LVGL::LVDisplay.get_scr_act()))
     set_cursor_manage(true)
@@ -76,7 +78,7 @@ class LVGUI::Keyboard < LVGUI::Widget
   def _animate_y(ending)
     LVGL::LVAnim.new().tap do |anim|
       anim.set_exec_cb(self, :lv_obj_set_y)
-      anim.set_time(300, 0)
+      anim.set_time(@animation_duration, 0)
       anim.set_values(get_y(), ending)
       anim.set_path_cb(LVGL::LVAnim::Path::EASE_OUT)
 

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -394,8 +394,18 @@ class UI
     @keyboard.set_ta(@ta)
     @keyboard.show()
 
-    bottom_space = @screen.get_height() - (@ta.get_y() + @ta.get_height())
-    delta = bottom_space - @keyboard.get_height() - 3*@unit
+    bottom_space = [
+      # Starting from the bottom of the screen
+      @screen.get_height(),
+      # Check where the textarea is
+      @ta.get_y() + @ta.get_height(),
+      # With a half-spacing
+      @spacing / 2,
+    ].inject(:-)
+
+    # See if they keyboard would cover it...
+    delta = bottom_space - @keyboard.get_height()
+    # And offset the page so to not cover it.
     offset_page(delta) if delta < 0
 
     @ta.on_submit = ->(value) do

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -306,6 +306,7 @@ class UI
       style.body_grad_color = BG_COLOR
       # Some themes will add a border to LVObject.
       style.body_border_width = 0
+      style.body_radius = 0
     end
   end
 

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -314,6 +314,7 @@ class UI
   def add_cover_bgrt()
     return unless has_bgrt?()
     @cover_bgrt = add_bgrt(@cover)
+    @cover_bgrt.set_click(false)
   end
 
   def add_textarea()

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -40,8 +40,8 @@ class UI
   def initialize()
     @vertical_offset = 0
 
-    add_screen
-    add_page
+    # The screen holds "everything".
+    add_screen()
 
     # Define a base unit from the size of the root widget.
     # Biggest of horizontal or vertical; one percent of its size.
@@ -49,16 +49,23 @@ class UI
     # Common spacing between widgets
     @spacing = 5 * @unit
 
-    add_logo
-    add_progress_bar
-    add_label
-    add_recovery
+    # The page holds the UI except for the keyboard.
+    # This can be used to move the display up, when showing the keyboard.
+    add_page()
+    # Then the keyboard.
+    add_keyboard()
 
-    add_textarea
-    add_keyboard
+    # We then build the page.
+    # Add the splash logo first,
+    add_logo()
+    # Then the different UI widgets
+    add_progress_bar()
+    add_label()
+    add_recovery()
+    add_textarea()
 
-    add_cover
-    add_cover_bgrt
+    add_cover()
+    add_cover_bgrt()
   end
 
   def add_canvas(parent, width, height)

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -379,7 +379,7 @@ class UI
   def offset_page(delta)
     LVGL::LVAnim.new().tap do |anim|
       anim.set_exec_cb(@page, :lv_obj_set_y)
-      anim.set_time(300, 0)
+      anim.set_time(@keyboard.animation_duration, 0)
       anim.set_values(@page.get_y(), delta)
       anim.set_path_cb(LVGL::LVAnim::Path::EASE_OUT)
 

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -63,6 +63,9 @@ class UI
     add_label()
     add_recovery()
     add_textarea()
+    # Once all those are added, we'll know where the bottom of them all is.
+    # Recompute the layout so it doesn't go off-page.
+    relayout_page()
 
     add_cover()
     add_cover_bgrt()
@@ -340,6 +343,25 @@ class UI
 
     LVGUI.focus_group.add_obj(@ta)
     LVGUI.focus_ring_disable()
+  end
+
+  def relayout_page()
+    page_bottom = @page.get_y() + @page.get_height()
+
+    # We know the widget that's the furthest down is the textarea. Let's use it for the metrics.
+    ta_bottom = @ta.get_y() + @ta.get_height()
+    # Add some space, so it's not tight against the bottom of the page.
+    ta_bottom = ta_bottom + (@spacing / 2)
+
+    # Is this going past the page's boundaries?
+    if ta_bottom > page_bottom
+      offset = page_bottom - ta_bottom
+      @page.get_children().each do |child|
+        unless child == @logo
+          child.set_y(child.get_y() + offset)
+        end
+      end
+    end
   end
 
   def add_keyboard()

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -81,7 +81,6 @@ class UI
   def add_bgrt(parent)
     # Work around the extension sniffing from the image decoders...
     File.symlink(BGRT_PATH, "/bgrt.bmp") unless File.exist?("/bgrt.bmp")
-    file = "/bgrt.bmp"
 
     # Temporarily makes an image to get its width/height...
     image = LVGL::LVImage.new(parent)

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -42,8 +42,13 @@ class UI
 
     add_screen
     add_page
-    # Biggest of horizontal or vertical; a percent.
+
+    # Define a base unit from the size of the root widget.
+    # Biggest of horizontal or vertical; one percent of its size.
     @unit = ([@screen.get_width, @screen.get_height].max * 0.01).ceil
+    # Common spacing between widgets
+    @spacing = 5 * @unit
+
     add_logo
     add_progress_bar
     add_label
@@ -170,7 +175,7 @@ class UI
     @label.set_align(LVGL::LABEL_ALIGN::CENTER)
 
     @label.set_width(@page.get_width * 0.9)
-    @label.set_pos(*center(@label, 0, 5*@unit))
+    @label.set_pos(*center(@label, 0, @spacing))
     @label.set_text("")
   end
 
@@ -200,7 +205,7 @@ class UI
     midpoint = @screen.get_height/2
     bottom_third = @screen.get_height() / 3.0 * 2
     logo_bottom = @logo.get_height() + @logo.get_y()
-    @vertical_offset = logo_bottom - midpoint + 5*@unit
+    @vertical_offset = logo_bottom - midpoint + @spacing
     @vertical_offset = 0 if @vertical_offset < 0
 
     # Some vendors ship a full-screen BGRT.
@@ -210,7 +215,7 @@ class UI
     # This assumption should hold since this is the assumptions for Windows.
     if (@vertical_offset + midpoint) > bottom_third
       # Force the UI area to be at the last third at the bottom.
-      @vertical_offset = bottom_third - midpoint + 5*@unit
+      @vertical_offset = bottom_third - midpoint + @spacing
     end
   end
 


### PR DESCRIPTION
When showing the BGRT, the current way this was made would make some things look *off*...

The TLDR is that it was possible for (bigger BGRTs) to make it so the textarea would be accidentally cropped past the edge of the page when showing the keyboard.

With these changes, the elements of the page (except the logo) are moved to be guaranteed to be on the page. They *may* overlap the logo, but that's something that can't be worked around with how the BGRT works.

It *could* be made better if we'd move the textarea out of the "main" area, and then push the label+logos up in a similar fashion we're doing with the keyboard, but that's not worth the pain at this point in time. I mainly wanted to fix the visual eyesore. That situation is anyway not expected to happen given how Microsoft defines the BGRT *should* be implemented.

* * *


### What was done

 - Checked with the `uefi-x86_64` VM.
 - Test on the target hardware where the issue was seen
 - Check potential issue with big BGRT and draw order
   - Might have been specific to the opacity "cover", but the progress bar was kind of weird when covering the space of the BGRT *during* the animation. Might require an actual bitmap and not reproduced with a simple rectangle.
   - It's because there are two copies of the logo. One "behind" the progress bar, and one "over" for the cover... See the comment “This is because opacity handles multiple overlaid objects wrong.”... It still is. It still "adds" the opacity of every child item. In turn, since the BGRT is possibly a white line-drawing on black background, this makes the box around the BGRT darker than the rest of the faded-in animation. There is no good solution here in the confines of how this older LVGL works.