### PR TITLE
Revert "overlay: vboot_reference cross-compilation fix"

### DIFF
--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -81,13 +81,7 @@ in
     # All that follows will have to be cleaned and then upstreamed.
     #
 
-    vboot_reference = super.vboot_reference.overrideAttrs(attrs: {
-      # https://github.com/NixOS/nixpkgs/pull/69039
-      postPatch = ''
-        substituteInPlace Makefile \
-          --replace "ar qc" '${final.stdenv.cc.bintools.targetPrefix}ar qc'
-      '';
-    });
+    # No such fixes as of now, this comment is merely a placeholder to keep the general structure.
 
     # Things specific to mobile-nixos.
     # Not necessarily internals, but they probably won't go into <nixpkgs>.


### PR DESCRIPTION
The corresponding changes have been merged upstream already. Furthermore the current implementation conflicts with upstream causing build failures. Removal from the overlay will fix this conflict while retaining all functionality.

For additional information see [the corresponding issue](https://redirect.github.com/mobile-nixos/mobile-nixos/issues/841#issuecomment-3348828592).

This reverts commit 474f3caa0afb00063e67874c5eb0d54064ea0431.

---

Above is the verbatim commit message.
I thought reverting it would be nice to keep the entire chain intact, linking to the old commit, etc..
YMMV of course, I'm open to input.

- Closes #841