### PR TITLE
devices: firmwareLinuxNonfree -> linux-firmware

### DIFF
--- a/devices/asus-dumo/firmware/default.nix
+++ b/devices/asus-dumo/firmware/default.nix
@@ -1,12 +1,12 @@
 { lib
 , runCommand
-, firmwareLinuxNonfree
+, linux-firmware
 }:
 
 # The minimum set of firmware files required for the device.
 runCommand "asus-dumo-firmware" {
-  src = firmwareLinuxNonfree;
-  meta.license = firmwareLinuxNonfree.meta.license;
+  src = linux-firmware;
+  meta.license = linux-firmware.meta.license;
 } ''
   for firmware in \
     ath10k/QCA6174/hw3.0 \

--- a/devices/families/mainline-chromeos-mt8183/firmware/default.nix
+++ b/devices/families/mainline-chromeos-mt8183/firmware/default.nix
@@ -1,12 +1,12 @@
 { lib
 , runCommand
-, firmwareLinuxNonfree
+, linux-firmware
 }:
 
 # The minimum set of firmware files required for the family
 runCommand "mt8183-chromeos-firmware" {
-  src = firmwareLinuxNonfree;
-  meta.license = firmwareLinuxNonfree.meta.license;
+  src = linux-firmware;
+  meta.license = linux-firmware.meta.license;
 } ''
   for firmware in \
     ath10k/QCA6174/hw3.0 \

--- a/devices/families/mainline-chromeos-sc7180/firmware/default.nix
+++ b/devices/families/mainline-chromeos-sc7180/firmware/default.nix
@@ -1,12 +1,12 @@
 { lib
 , runCommand
-, firmwareLinuxNonfree
+, linux-firmware
 }:
 
 # The minimum redistributable set of firmware files required for the device.
 runCommand "chromeos-sc7180-firmware" {
-  src = firmwareLinuxNonfree;
-  meta.license = firmwareLinuxNonfree.meta.license;
+  src = linux-firmware;
+  meta.license = linux-firmware.meta.license;
 } ''
   for firmware in \
     ath10k/WCN3990/hw1.0 \

--- a/devices/pine64-pinephonepro/firmware/default.nix
+++ b/devices/pine64-pinephonepro/firmware/default.nix
@@ -1,6 +1,6 @@
 { lib
 , runCommand
-, firmwareLinuxNonfree
+, linux-firmware
 , fetchgit
 , fetchFromGitLab
 }:
@@ -29,7 +29,7 @@ in
 
 # The minimum set of firmware files required for the device.
 runCommand "pine64-pinephonepro-firmware" {
-  src = firmwareLinuxNonfree;
+  src = linux-firmware;
 } ''
   for firmware in \
     rockchip/dptx.bin \


### PR DESCRIPTION
The original package rename in nixpkgs is from 2022, thus using the new package name should be safe virtually everywhere. Meanwhile nixos-unstable has [replaced the old package name with a throw in 2025](https://redirect.github.com/NixOS/nixpkgs/commit/853d9f31ea6206e86b72db1ba221a12cb503510f), making migration necessary.

Fixes: #844

---

The above is the commit message verbatim.

This fixes evaluation for my Lenovo *krane* Chromebook while my PinePhone continues to evaluate normally.