### PR TITLE
image-builder: utillinux -> util-linux

### DIFF
--- a/overlay/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
+++ b/overlay/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
@@ -1,7 +1,7 @@
 { stdenvNoCC
 , lib
 , gptfdisk
-, utillinux
+, util-linux
 , config
 }:
 
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     gptfdisk
-    utillinux
+    util-linux
   ];
 
   buildCommand = let

--- a/overlay/image-builder/disk-image/partitioning-scheme/mbr/builder.nix
+++ b/overlay/image-builder/disk-image/partitioning-scheme/mbr/builder.nix
@@ -1,6 +1,6 @@
 { stdenvNoCC
 , lib
-, utillinux
+, util-linux
 , config
 }:
 
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
   ;
 
   nativeBuildInputs = [
-    utillinux
+    util-linux
   ];
 
   buildCommand = let


### PR DESCRIPTION
Same as in https://github.com/mobile-nixos/mobile-nixos/pull/513

Currently qemu image doesn't build without it with fresh nixpkgs.