### PR TITLE
modules/initrd-kernel: Take recurseIntoAttrs from lib instead of pkgs

### DIFF
--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -242,7 +242,7 @@ in
             extend = _: self;
           };
         in self
-        else (pkgs.recurseIntoAttrs (pkgs.linuxPackagesFor cfg.package))
+        else (lib.recurseIntoAttrs (pkgs.linuxPackagesFor cfg.package))
       );
 
       system.boot.loader.kernelFile = mkIf (cfg.package != null && cfg.package ? file) (


### PR DESCRIPTION
Without this commit, I get the following warning:
```
trace: evaluation warning: 'recurseIntoAttrs' has been removed from pkgs, use `lib.recurseIntoAttrs` instead
```
https://github.com/NixOS/nixpkgs/commit/03bb7d81954de1161110e4b8da50bd7e14f3b17e removed `recurseIntoAttrs` from `pkgs`, so follow the suggestion and use `lib.recurseIntoAttrs` instead.