### PR TITLE
modules/system-target: Prevent misuse of `nixpkgs.*` for automatic cross

### DIFF
--- a/modules/system-target.nix
+++ b/modules/system-target.nix
@@ -22,11 +22,20 @@ let
   # Use JSON to escape values for printing
   e = builtins.toJSON;
 
-  # When `nixpkgs` is built on a different platform than it will be running on.
-  isCross = deviceHostPlatform.system != localSystem.system;
-
   # The host platform selected by the Mobile device configuration
   deviceHostPlatform = elaborate cfg.system;
+
+  # The `config.nixpkgs` attribute set value defaults are not supposed to be read.
+  # Let's try anyway, and assume a pure evaluation with i.e. `[flake]lib.nixosSystem` is in play when that fails.
+  # This should be safe, as this is only used to automatically compute cross-compilation in “impure” environments.
+  hasLocalSystem =
+    (builtins.tryEval (
+      config.nixpkgs.localSystem
+    )).success
+  ;
+
+  # When `nixpkgs` is built on a different platform than it will be running on.
+  isCross = hasLocalSystem && deviceHostPlatform.system != localSystem.system;
 
   # Be mindful about using `config` values that depends on `nixpkgs.buildPlatform`!
   # This is used when setting `nixpkgs.buildPlatform`, so any values depending on `nixpkgs.buildPlatform`,


### PR DESCRIPTION
This prevents a `nixpkgs.*` value from being used to configure automatic cross in situations where automatic cross can't be guessed.

Fixes #849

* * *

cc @imnotpoz, reporter of the issue.

cc @Luflosi since this seems somewhat related to #820. I want to make sure this isn't causing regressions or unwanted behaviour in your configs.

* * *

### What was done

 - Tested against the minimal reproducer 
    ```
    ~/.../issue-849/mobile-nixos-oneplus-enchilada $ nix repl --show-trace --expr '{ flake = builtins.getFlake (toString ./.); }'
    Lix 2.93.3
    Type :? for help.
    Loading installable ''...
    Added 1 variables.
    nix-repl> flake.outputs.nixosConfigurations.phone.pkgs.stdenv.hostPlatform.system
    • Updated input 'mobile-nixos':
       'github:mobile-nixos/mobile-nixos/1e38d4027bbb944f2af1b3241eabd9ad9c950c84' (2025-10-30)
      → 'path:/Users/samuel/Projects/mobile-nixos/issue-849/mobile-nixos?lastModified=1763053008&narHash=sha256-vXnEIOH941fu1ng3crxJR1p/0OWO5PK0IbbylnSN2ME%3D' (2025-11-13)
    "aarch64-linux"
   ```

### What needs to be done

 - [ ] Check against my system config (maybe)