### PR TITLE
linux: remove pie from hardeningDisable

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -522,7 +522,7 @@ stdenv.mkDerivation (inputArgs // {
     + maybeString postInstall
   ;
 
-  hardeningDisable = [ "bindnow" "format" "fortify" "stackprotector" "pic" "pie" ];
+  hardeningDisable = [ "bindnow" "format" "fortify" "stackprotector" "pic" ];
 
   makeFlags = [
     "O=$(buildRoot)"


### PR DESCRIPTION
Analogous to Nixpkgs commit 1d0624ac373ccac132313addc5943d5ce3fc1ce3.

Without this, I get the following warning with the latest Nixpkgs:
```
trace: evaluation warning: The 'pie' hardening flag has been removed in favor of enabling PIE by default in compilers and should no longer be used. PIE can be disabled with the -no-pie compiler flag, but this is usually not necessary as most build systems pass this if needed. Usage of the 'pie' hardening flag will become an error in future.
```

This warning was added in Nixpkgs commit 4a6e2ebd8a5055048bfb02d991975f2393a3b6c6.