### PR TITLE
treewide: fix system.extraSystemBuilderCmds deprecation warning

### DIFF
--- a/examples/installer/modules/boot-closure.nix
+++ b/examples/installer/modules/boot-closure.nix
@@ -12,7 +12,7 @@ in
 {
   # Pins pre-built artifacts within the system closure that are going to be
   # used by the installer.
-  system.extraSystemBuilderCmds = ''
+  system.systemBuilderCommands = ''
     echo ":: Adding pre-built boot files to closure..."
     (
       PS4=" $ "; set -x

--- a/modules/shared-rootfs.nix
+++ b/modules/shared-rootfs.nix
@@ -24,7 +24,7 @@ in
     system.boot.loader.initrdFile = "no-initrd";
 
     # And totally obliterate device-specific files from stage-2.
-    system.extraSystemBuilderCmds = ''
+    system.systemBuilderCommands = ''
       echo ":: Removing non-generic system items..."
       (
         cd $out

--- a/modules/system-build.nix
+++ b/modules/system-build.nix
@@ -14,7 +14,7 @@ let
 in
 {
   config = mkIf (config.mobile.enable && !config.mobile.rootfs.shared.enabled) {
-    system.extraSystemBuilderCmds = ''
+    system.systemBuilderCommands = ''
       echo ":: Adding Mobile NixOS information to the build..."
       (
         PS4=" $ "; set -x


### PR DESCRIPTION
Without this, I get the following warning with the latest Nixpkgs:
```
trace: evaluation warning: The option `system.extraSystemBuilderCmds' defined in `/nix/store/8ggbaqxkxgxbxpzdl0a2wqr2i4a19k1b-source/modules/system-build.nix' has been renamed to `system.systemBuilderCommands'.
```

This warning was introduced in Nixpkgs commit 41b98b4a8a38ee9aa96a0cf42414e9308514fc66.