### PR TITLE
Update of qrtr packages

### DIFF
--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -43,6 +43,8 @@ in
     libusbgx = callPackage ./libusbgx {};
     gadget-tool = callPackage ./gt {}; # upstream this is called "gt", which is very Unix.
 
+    pil-squasher = callPackage ./pil-squasher { };
+
     qrtr = callPackage ./qrtr/qrtr.nix { };
     qmic = callPackage ./qrtr/qmic.nix { };
     tqftpserv = callPackage ./qrtr/tqftpserv.nix { };

--- a/overlay/pil-squasher/default.nix
+++ b/overlay/pil-squasher/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "pil-squasher";
+  version = "unstable-2024-07-11";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "pil-squasher";
+    rev = "3c9f8b8756ba6e4dbf9958570fd4c9aea7a70cf4";
+    hash = "sha256-MEW85w3RQhY3tPaWtH7OO22VKZrjwYUWBWnF3IF4YC0=";
+  };
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = {
+    description = "Qualcomm firmware squasher";
+    longDescription = ''
+      Tool to convert Qualcomm firmware from split format (.mdt + .bXX files)
+      to monolithic .mbn files for mainline Linux kernel.
+    '';
+    homepage = "https://github.com/linux-msm/pil-squasher";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/overlay/qrtr/pd-mapper-firmware-path.diff
+++ b/overlay/qrtr/pd-mapper-firmware-path.diff
@@ -2,13 +2,12 @@ diff --git a/pd-mapper.c b/pd-mapper.c
 index f5d45ee..a1f1179 100644
 --- a/pd-mapper.c
 +++ b/pd-mapper.c
-@@ -193,7 +193,7 @@ static int pd_load_map(const char *file)
- 	return 0;
+@@ -207,7 +207,7 @@ static int concat_path(char *base_path, char *firmware_path, char *path)
  }
-
+ 
+ #ifndef ANDROID
 -#define FIRMWARE_BASE	"/lib/firmware/"
-+#define FIRMWARE_BASE	"/run/current-system/sw/share/uncompressed-firmware/"
-
- static int pd_enumerate_jsons(struct assoc *json_set)
- {
-
++#define FIRMWARE_BASE	"/run/current-system/firmware/"
+ #define FIRMWARE_PARAM_PATH	"/sys/module/firmware_class/parameters/path"
+ 
+ static DIR *opendir_firmware(char *firmware_path, char *out_path_opened)

--- a/overlay/qrtr/pd-mapper.nix
+++ b/overlay/qrtr/pd-mapper.nix
@@ -1,16 +1,24 @@
-{ stdenv, lib, fetchFromGitHub, qrtr }:
-
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  qrtr,
+  xz,
+}:
 stdenv.mkDerivation {
   pname = "pd-mapper";
-  version = "unstable-2022-02-08";
+  version = "unstable-2025-12-30";
 
-  buildInputs = [ qrtr ];
+  buildInputs = [
+    qrtr
+    xz
+  ];
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "pd-mapper";
-    rev = "9d78fc0c6143c4d1b7198c57be72a6699ce764c4";
-    hash = "sha256-vQZZ3WtZGh5OEw0EmlmT/My/cY6VRruuicsFR0YCQOw=";
+    rev = "5ecd2fe926aca7abfe40724177f63b942cff3947";
+    hash = "sha256-I5/N24KONtNRSub00Mqh1GoMHO2qQKTj/ts2N6DQdPc=";
   };
 
   patches = [
@@ -21,8 +29,9 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Qualcomm PD mapper";
-    homepage = "https://github.com/andersson/pd-mapper";
+    homepage = "https://github.com/linux-msm/pd-mapper";
     license = licenses.bsd3;
+    maintainers = [ ];
     platforms = platforms.aarch64;
   };
 }

--- a/overlay/qrtr/qmic.nix
+++ b/overlay/qrtr/qmic.nix
@@ -1,22 +1,26 @@
-{ lib, stdenv, fetchFromGitHub }:
-
-stdenv.mkDerivation {
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation rec {
   pname = "qmic";
-  version = "unstable-2022-07-18";
+  version = "1.0";
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "qmic";
-    rev = "ed896c97dc2b3b7edcba103e02fd0f3368b56ddd";
-    sha256 = "sha256-llum30rTCtlxN4DlLk+buv4X6FR3KY5cwuODUenwzy4=";
+    tag = "v${version}";
+    hash = "sha256-0/mIg98pN66ZaVsQ6KmZINuNfiKvdEHMsqDx0iciF8w=";
   };
 
   installFlags = [ "prefix=$(out)" ];
 
   meta = with lib; {
     description = "QMI IDL compiler";
-    homepage = "https://github.com/andersson/qmic";
+    homepage = "https://github.com/linux-msm/qmic";
     license = licenses.bsd3;
-    platforms = platforms.aarch64;
+    maintainers = [ ];
+    platforms = platforms.linux;
   };
 }

--- a/overlay/qrtr/qrtr.nix
+++ b/overlay/qrtr/qrtr.nix
@@ -1,22 +1,37 @@
-{ stdenv, lib, fetchFromGitHub }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  systemd,
+}:
 
 stdenv.mkDerivation {
   pname = "qrtr";
-  version = "unstable-2020-12-07";
+  version = "unstable-2025-12-08";
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "qrtr";
-    rev = "9dc7a88548c27983e06465d3fbba2ba27d4bc050";
-    hash = "sha256-eJyErfLpIv4ndX2MPtjLTOQXrcWugQo/03Kz4S8S0xw=";
+    rev = "a38e9afbe76270262dc157749602229b8b681f09";
+    hash = "sha256-KxWDiTl+vbGZpB+OWYvH2/NvCWCJXZcpegAnkrG0UIo=";
   };
 
-  installFlags = [ "prefix=$(out)" ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [ systemd ];
 
   meta = with lib; {
-    description = "QMI IDL compiler";
-    homepage = "https://github.com/andersson/qrtr";
+    description = "Qualcomm IPC Router userspace tools and library";
+    homepage = "https://github.com/linux-msm/qrtr";
     license = licenses.bsd3;
-    platforms = platforms.aarch64;
+    maintainers = with lib.maintainers; [ ];
+    platforms = platforms.linux;
   };
 }

--- a/overlay/qrtr/rmtfs.nix
+++ b/overlay/qrtr/rmtfs.nix
@@ -1,24 +1,35 @@
-{ stdenv, lib, fetchFromGitHub, udev, qrtr, qmic }:
-
-stdenv.mkDerivation {
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  udev,
+  qrtr,
+  qmic,
+}:
+stdenv.mkDerivation rec {
   pname = "rmtfs";
-  version = "unstable-2022-07-18";
+  version = "1.2";
 
-  buildInputs = [ udev qrtr qmic ];
+  buildInputs = [
+    udev
+    qrtr
+    qmic
+  ];
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "rmtfs";
-    rev = "695d0668ffa6e2a4bf6e676f3c58a444a5d67690";
-    hash = "sha256-00KOjdkwcAER261lleSl7OVDEAEbDyW9MWxDd0GI8KA=";
+    tag = "v${version}";
+    hash = "sha256-fjyiSl9a98goqd/tQSylcSZFM5NAK9Kaa+5M28wa78U=";
   };
 
   installFlags = [ "prefix=$(out)" ];
 
   meta = with lib; {
     description = "Qualcomm Remote Filesystem Service";
-    homepage = "https://github.com/andersson/rmtfs";
+    homepage = "https://github.com/linux-msm/rmtfs";
     license = licenses.bsd3;
+    maintainers = [ ];
     platforms = platforms.aarch64;
   };
 }

--- a/overlay/qrtr/tqftpserv-firmware-path.diff
+++ b/overlay/qrtr/tqftpserv-firmware-path.diff
@@ -2,13 +2,12 @@ diff --git a/translate.c b/translate.c
 index e95dee5..f3f0811 100644
 --- a/translate.c
 +++ b/translate.c
-@@ -45,7 +45,7 @@
- #define READONLY_PATH	"/readonly/firmware/image/"
+@@ -22,7 +22,7 @@
  #define READWRITE_PATH	"/readwrite/"
  
+ #ifndef ANDROID
 -#define FIRMWARE_BASE	"/lib/firmware/"
-+#define FIRMWARE_BASE	"/run/current-system/sw/share/uncompressed-firmware/"
- 
- /**
-  * translate_readonly() - open "file" residing with remoteproc firmware
-
++#define FIRMWARE_BASE	"/run/current-system/firmware/"
+ #define TQFTPSERV_TMP	"/tmp/tqftpserv"
+ #define UPDATES_DIR	"updates/"
+ #else

--- a/overlay/qrtr/tqftpserv.nix
+++ b/overlay/qrtr/tqftpserv.nix
@@ -1,28 +1,46 @@
-{ stdenv, lib, fetchFromGitHub, qrtr }:
-
-stdenv.mkDerivation {
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  qrtr,
+  zstd,
+  systemd,
+}:
+stdenv.mkDerivation rec {
   pname = "tqftpserv";
-  version = "unstable-2020-02-07";
+  version = "1.1.1";
 
-  buildInputs = [ qrtr ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    qrtr
+    zstd
+    systemd
+  ];
 
   src = fetchFromGitHub {
-    owner = "andersson";
+    owner = "linux-msm";
     repo = "tqftpserv";
-    rev = "783425b550de2a359db6aa3b41577c3fbaae5903";
-    hash = "sha256-Qybmd/mXhKotCem/xN0bOvWyAp2VJf+Hdh6PQyFnd3s==";
+    tag = "v${version}";
+    hash = "sha256-cwoAinvO2bQ6Ylx1zzh5ycE7om2vgk9uqyDJhpy6jP4=";
   };
 
   patches = [
     ./tqftpserv-firmware-path.diff
   ];
 
-  installFlags = [ "prefix=$(out)" ];
-
   meta = with lib; {
     description = "Trivial File Transfer Protocol server over AF_QIPCRTR";
-    homepage = "https://github.com/andersson/tqftpserv";
+    homepage = "https://github.com/linux-msm/tqftpserv";
     license = licenses.bsd3;
+    maintainers = [ ];
     platforms = platforms.aarch64;
   };
 }


### PR DESCRIPTION
Hi @samueldr ,

here's update of the qrtr packages. Added versions where appropriate.

Also the `tqftpserv` is now dependent on `systemd`.


What about upstreaming these to nixpkgs? I have aarch64 laptop (Lenovo x13s) that would also benefit.