### PR TITLE
nixpkgs update requires xorg package handling changes (packages are at toplevel now)

### DIFF
--- a/examples/hello/configuration.nix
+++ b/examples/hello/configuration.nix
@@ -120,9 +120,11 @@ in
   # The LVGUI interface can be used with volume keys for selecting
   # and power to activate an option.
   # Without this, logind just powers off :).
-  services.logind.extraConfig = ''
-    HandlePowerKey=ignore
-  '';
+  services.logind.settings = {
+    Login = {
+      HandlePowerKey = "ignore";
+    };
+  };
 
   system.build = {
     app-simulator = app.simulator;

--- a/examples/installer/modules/installer-gui.nix
+++ b/examples/installer/modules/installer-gui.nix
@@ -71,9 +71,11 @@ in
   # The LVGUI interface can be used with volume keys for selecting
   # and power to activate an option.
   # Without this, logind just powers off :).
-  services.logind.extraConfig = ''
-    HandlePowerKey=ignore
-  '';
+  services.logind.settings = {
+    Login = {
+      HandlePowerKey = "ignore";
+    };
+  };
 
   boot.kernelParams = lib.mkBefore [
     "fbcon=vc:2-6"

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -15,14 +15,14 @@ let
   } ''
     (PS4=" $ "; set -x
     mkdir -vp "$out/xkb"
-    cp -vr -t "$out/xkb/" ${pkgs.xorg.xkeyboardconfig}/share/X11/xkb/*
-    cp -vr ${pkgs.xorg.libX11.out}/share/X11/locale $out/locale
+    cp -vr -t "$out/xkb/" ${pkgs.xkeyboard-config}/share/X11/xkb/*
+    cp -vr ${pkgs.libX11.out}/share/X11/locale $out/locale
     )
 
-    for f in $(grep -lIiR '${pkgs.xorg.libX11.out}' $out); do
+    for f in $(grep -lIiR '${pkgs.libX11.out}' $out); do
       printf ':: substituting original path for $out in "%s".\n' "$f"
       substituteInPlace $f \
-        --replace "${pkgs.xorg.libX11.out}/share/X11/locale/en_US.UTF-8/Compose" "$out/locale/en_US.UTF-8/Compose"
+        --replace "${pkgs.libX11.out}/share/X11/locale/en_US.UTF-8/Compose" "$out/locale/en_US.UTF-8/Compose"
     done
   '';
 in

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixos-unstable",
-      "url": "https://releases.nixos.org/nixos/unstable/nixos-25.11pre833752.fc02ee70efb8/nixexprs.tar.xz",
-      "hash": "13djcw3j6mybs22ciimrfwfyhgy3wqr462jvw8z7rzk90wj9k94h"
+      "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre940249.00c21e4c93d9/nixexprs.tar.xz",
+      "hash": "0zmmghaihnsmxdiig5fymah4xy6k2s0s423v69bp0id4gbj8r77h"
     }
   },
   "version": 5

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixos-unstable",
-      "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre940249.00c21e4c93d9/nixexprs.tar.xz",
-      "hash": "0zmmghaihnsmxdiig5fymah4xy6k2s0s423v69bp0id4gbj8r77h"
+      "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre945868.a82ccc39b39b/nixexprs.tar.xz",
+      "hash": "1p66vk46pn839jakgq3ijszh49s8d6cdmfbrnmi1dnnfz6770k1i"
     }
   },
   "version": 5

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -58,21 +58,11 @@ in
     # Totally not upstreamable stuff.
     #
 
-    xorg = (
-      # Backward compatibility shim
-      # Fixes eval after https://github.com/NixOS/nixpkgs/pull/199912
-      # Can be removed on or after 2023-05-16
-      if super.xorg ? overrideScope'
-      then super.xorg.overrideScope'
-      else super.xorg.overrideScope
-    ) (final: super: {
-      xf86videofbdev = super.xf86videofbdev.overrideAttrs({patches ? [], ...}: {
-        patches = patches ++ [
-          ./xserver/0001-HACK-fbdev-don-t-bail-on-mode-initialization-fail.patch
-        ];
-      });
-    }) # See all-packages.nix for more about this messy composition :/
-    // { inherit (final) xlibsWrapper; };
+    xf86-video-fbdev = super.xf86-video-fbdev.overrideAttrs({patches ? [], ...}: {
+      patches = patches ++ [
+        ./xserver/0001-HACK-fbdev-don-t-bail-on-mode-initialization-fail.patch
+      ];
+    });
 
     #
     # Fixes to upstream

--- a/release.nix
+++ b/release.nix
@@ -106,11 +106,6 @@ let
     in
     eval: let overlay = (lib.genAttrs overlayAttrNames (name: eval.pkgs.${name})); in
     overlay // {
-      # We only "monkey patch" over top of the main nixos one.
-      xorg = {
-        xf86videofbdev = eval.pkgs.xorg.xf86videofbdev;
-      };
-
       # lib-like attributes...
       # How should we handle these?
       image-builder = null;


### PR DESCRIPTION
As mentioned in https://github.com/mobile-nixos/mobile-nixos/pull/863#issuecomment-3908919764 the packages have moved to the toplevel.
This draft PR is basically just for testing and documentation purposes, if these changes work they should probably be integrated into the existing PR (as a single solidified update instead of two chained updates).