### PR TITLE
Fix more aliases

### DIFF
--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -16,13 +16,13 @@ let
     (PS4=" $ "; set -x
     mkdir -vp "$out/xkb"
     cp -vr -t "$out/xkb/" ${pkgs.xkeyboard-config}/share/X11/xkb/*
-    cp -vr ${pkgs.libX11.out}/share/X11/locale $out/locale
+    cp -vr ${pkgs.libx11.out}/share/X11/locale $out/locale
     )
 
-    for f in $(grep -lIiR '${pkgs.libX11.out}' $out); do
+    for f in $(grep -lIiR '${pkgs.libx11.out}' $out); do
       printf ':: substituting original path for $out in "%s".\n' "$f"
       substituteInPlace $f \
-        --replace "${pkgs.libX11.out}/share/X11/locale/en_US.UTF-8/Compose" "$out/locale/en_US.UTF-8/Compose"
+        --replace "${pkgs.libx11.out}/share/X11/locale/en_US.UTF-8/Compose" "$out/locale/en_US.UTF-8/Compose"
     done
   '';
 in

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -15,7 +15,7 @@ let
   } ''
     (PS4=" $ "; set -x
     mkdir -vp "$out/xkb"
-    cp -vr -t "$out/xkb/" ${pkgs.xkeyboardconfig}/share/X11/xkb/*
+    cp -vr -t "$out/xkb/" ${pkgs.xkeyboard-config}/share/X11/xkb/*
     cp -vr ${pkgs.libX11.out}/share/X11/locale $out/locale
     )
 

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -54,7 +54,7 @@ let
     nativeBuildInputs = with pkgs; [
       dtc
       ubootTools
-      vboot_reference
+      vboot-utils
       xz
     ];
   } ''
@@ -79,8 +79,8 @@ let
       --bootloader bootloader.bin \
       --vmlinuz vmlinux.uimg \
       --arch ${arch} \
-      --keyblock ${pkgs.vboot_reference}/share/vboot/devkeys/kernel.keyblock \
-      --signprivate ${pkgs.vboot_reference}/share/vboot/devkeys/kernel_data_key.vbprivk \
+      --keyblock ${pkgs.vboot-utils}/share/vboot/devkeys/kernel.keyblock \
+      --signprivate ${pkgs.vboot-utils}/share/vboot/devkeys/kernel_data_key.vbprivk \
       --config ${kpart_config} \
       --pack $out
   '';
@@ -138,7 +138,7 @@ in
         additionalCommands = ''
           echo ":: Making image bootable by depthcharge"
           (PS4=" $ "; set -x
-          ${pkgs.buildPackages.vboot_reference}/bin/cgpt ${concatStringsSep " " [
+          ${pkgs.buildPackages.vboot-utils}/bin/cgpt ${concatStringsSep " " [
             "add"
             "-i 1"  # Work on the first partition (instead of adding)
             "-S 1"  # Mark as successful (so it'll be booted from)
@@ -146,7 +146,7 @@ in
             "-P 10" # Priority
             "$img"
           ]}
-          ${pkgs.buildPackages.vboot_reference}/bin/cgpt ${concatStringsSep " " [
+          ${pkgs.buildPackages.vboot-utils}/bin/cgpt ${concatStringsSep " " [
             "show"
             "$img"
           ]}

--- a/overlay/mobile-nixos/gui-assets/default.nix
+++ b/overlay/mobile-nixos/gui-assets/default.nix
@@ -3,7 +3,7 @@
 , roboto
 , fira-mono
 , font-awesome_5
-, nodePackages
+, svgo
 }:
 
 let
@@ -11,7 +11,7 @@ let
 in
 runCommand "gui-assets" {
   nativeBuildInputs = [
-    nodePackages.svgo
+    svgo
   ];
 } ''
 mkdir -p $out

--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -26,7 +26,7 @@
 
 , perl
 , bc
-, nettools
+, net-tools
 , openssl
 , rsync
 , gmp
@@ -216,7 +216,7 @@ stdenv.mkDerivation (inputArgs // {
   updateConfigFromStructuredConfig = !__mobile-nixos-useStrictKernelConfig;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr ]
+  nativeBuildInputs = [ perl bc net-tools openssl rsync gmp libmpc mpfr ]
     ++ optional (platform.linux-kernel.target == "uImage") buildPackages.ubootTools
     ++ optional (lib.versionAtLeast version "4.14" && lib.versionOlder version "5.8") libelf
     ++ optional (lib.versionAtLeast version "4.15") util-linux

--- a/release.nix
+++ b/release.nix
@@ -76,8 +76,24 @@ let
   inherit (pkgs) lib releaseTools;
   inherit (mobileReleaseTools.withPkgs pkgs)
     evalFor
-    evalWithConfiguration
     specialConfig
+  ;
+
+  # Add `allowAliases = false` to `evalWithConfiguration` for the release evaluations.
+  evalWithConfiguration = 
+    config: device:
+    (mobileReleaseTools.withPkgs pkgs).evalWithConfiguration
+    {
+      imports = [
+        {
+          nixpkgs.config = {
+            allowAliases = false;
+          };
+        }
+        config
+      ];
+    }
+    device
   ;
 
   # Systems we should eval for, per host system.


### PR DESCRIPTION
As reported by @benaryorg in https://github.com/mobile-nixos/mobile-nixos/pull/866#issuecomment-3921522923, some aliases still were used, even though an attempt was made in https://github.com/mobile-nixos/mobile-nixos/pull/866 to solve this by [disallowing aliases](https://github.com/mobile-nixos/mobile-nixos/commit/396a34a4a5421e1a69d9f94cfc1d583a4d6a5f53).

Turns out that since the evaluation of the systems in `release.nix` were not using *that* `pkgs` instance, since they're evaluating `nixos/default.nix` from *that* `pkgs.path`... The config in `release.nix` for `allowAliases` was not kept around.

Oops.