### PR TITLE
fix broken string indentation warning

### DIFF
--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -57,7 +57,7 @@ let
     ''
     else if flashingMethod == "odin" then ''
       heimdall flash \
-        --BOOT "$dir"/boot.img ${optionalString has_recovery_partition ''\
+        --BOOT "$dir"/boot.img ${optionalString has_recovery_partition ''
         --RECOVERY "$dir"/recovery.img
       ''}
     ''


### PR DESCRIPTION
Newer versions of Lix ship with the following warning:

```text
warning: Whitespace calculations for indentation stripping in a multiline ''-string include the first line, so putting text on it will effectively disable all indentation stripping. To fix this, simply break the line right after the string starts. Use --extra-deprecated-features broken-string-indentation to silence this warning.
```

The code in question does trigger this.
What the code is trying to do is inject a backslash on the first line which is a continuation. The following line is then supposed to have indentation, however the indentation is off this way since all of the whitespace is included instead of just one level. Therefore it does not achieve what it is trying to. Removing the backslash will instead put the text on the same line with no indentation. Given the script has been generating with a trailing space for systems without a recovery partition up until now, no effort has been made to ensure additional formatting in the output.

Here's a hacky *git grep* used to look for other occurrences (without having to eval the entire repo):

```bash
git grep -P "''[^\n;) $}]"
```