### PR TITLE
boot/overlay: libinput without lua plugins

### DIFF
--- a/boot/overlay/libinput/default.nix
+++ b/boot/overlay/libinput/default.nix
@@ -4,20 +4,22 @@
 , mtdev
 , buildPackages
 }:
-(libinput.override {
-      libwacom = null;
-      documentationSupport = false;
-      doxygen = null;
-      graphviz = null;
-      eventGUISupport = false;
-      cairo = null;
-      glib = null;
-      gtk3 = null;
-      testsSupport = false;
-      check = null;
-      valgrind = null;
-      python3 = null;
-})
+(libinput.override ({
+    libwacom = null;
+    documentationSupport = false;
+    doxygen = null;
+    graphviz = null;
+    eventGUISupport = false;
+    cairo = null;
+    glib = null;
+    gtk3 = null;
+    testsSupport = false;
+    check = null;
+    valgrind = null;
+    python3 = null;
+  }
+  // lib.optionalAttrs (lib.functionArgs libinput.override ? lua5_4) { lua5_4 = null; }
+))
 .overrideAttrs({ nativeBuildInputs ? [], mesonFlags, ... }: {
   buildInputs = [
     libevdev
@@ -28,5 +30,6 @@
   ];
   mesonFlags = mesonFlags ++ [
     (lib.mesonBool "libwacom" false)
+    (lib.mesonEnable "lua-plugins" false)
   ];
 })

--- a/boot/overlay/libinput/default.nix
+++ b/boot/overlay/libinput/default.nix
@@ -1,4 +1,5 @@
-{ libinput
+{ lib
+, libinput
 , libevdev
 , mtdev
 , buildPackages
@@ -26,6 +27,6 @@
     buildPackages.udev
   ];
   mesonFlags = mesonFlags ++ [
-    "-Dlibwacom=false"
+    (lib.mesonBool "libwacom" false)
   ];
 })


### PR DESCRIPTION
Upstream *libinput* has introduced plugins written in the Lua language.
At time of writing these seem to be small units of code aimed at remapping keys or performing other QoL changes to the input devices.
These changes are strictly speaking optional and due to the size constraints of the environment this overlay is used in, it seems reasonable to disable these plugins.

This might need to be revisited in the future.

The code is written in a way that is compatible with libinput derivations with and without Lua.

---

Above is the (relevant) commit message verbatim.

Fixes #875 