### PR TITLE
kernel/builder: fix cross-compilation of config validator

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -169,7 +169,9 @@ in
 
 let
   evaluatedStructuredConfig = import ./eval-config.nix {
-    inherit lib path version writeShellScript;
+    inherit lib path version;
+    runtimeShell = buildPackages.runtimeShell;
+    inherit writeTextFile;
     structuredConfig = (systemBuild-structuredConfig version);
   };
 

--- a/overlay/mobile-nixos/kernel/eval-config.nix
+++ b/overlay/mobile-nixos/kernel/eval-config.nix
@@ -4,7 +4,8 @@
 , modules ? []
 , structuredConfig
 , version
-, writeShellScript
+, runtimeShell
+, writeTextFile
 }: rec {
   module = import (path + "/nixos/modules/system/boot/kernel_config.nix");
   config = (lib.evalModules {
@@ -43,8 +44,12 @@
           mkConf = cfg: lib.concatStringsSep "\n" (lib.mapAttrsToList mkConfigLine cfg);
           configfile = mkConf config.settings;
 
-          validatorSnippet = writeShellScript "kernel-configuration-validator-snippet" ''
-            (
+          validatorSnippet = writeTextFile {
+            name = "kernel-configuration-validator-snippet";
+            executable = true;
+            text = ''
+              #!${runtimeShell}
+              (
             # This can be executed outside of a Nix build script.
             set -eu
             set -o pipefail
@@ -140,7 +145,8 @@
               echo "... continuing."
             fi
             )
-          '';
+            '';
+          };
         in
         {
           options = {


### PR DESCRIPTION
writeShellScript produces a script with the target platform's shell in its shebang. When cross-compiling (e.g. building aarch64 on x86_64), this makes the validator script non-executable on the build host, causing the kernel build to fail with exit code 126.

This replace `writeShellScript` with `writeTextFile` + an explicit shebang using `buildPackages.runtimeShell` so the script runs on the build machine regardless of target architecture.
