### PR TITLE
devices: add SM8250 (Snapdragon 865/865+/870) family support

### DIFF
--- a/devices/families/sm8250-mainline/default.nix
+++ b/devices/families/sm8250-mainline/default.nix
@@ -1,0 +1,54 @@
+{ config, lib, pkgs, ... }:
+
+let
+  qcomVideoFirmware = pkgs.runCommand "sm8250-video-firmware" {} ''
+    dir=$out/lib/firmware/qcom
+    mkdir -p $dir
+    cp -v ${pkgs.linux-firmware}/lib/firmware/qcom/a650* $dir
+  '';
+
+  deviceFirmware = lib.optional (config.mobile.device.enableFirmware && config.mobile.device.firmware != null) (
+    pkgs.runCommand "sm8250-device-initrd-firmware" {} ''
+      cp -vrf ${config.mobile.device.firmware} $out
+      chmod -R +w $out
+    ''
+  );
+in
+{
+  mobile.hardware = {
+    soc = "qualcomm-sm8250";
+  };
+
+  mobile.boot.stage-1 = {
+    compression = "xz";
+    firmware = [ qcomVideoFirmware ] ++ deviceFirmware;
+  };
+
+  hardware.enableRedistributableFirmware = true;
+
+  mobile.system.type = "android";
+  mobile.system.android = {
+    ab_partitions = lib.mkDefault true;
+    bootimg.flash = {
+      offset_base = "0x00000000";
+      offset_kernel = "0x00008000";
+      offset_ramdisk = "0x01000000";
+      offset_second = "0x00f00000";
+      offset_tags = "0x00000100";
+      pagesize = "4096";
+    };
+    appendDTB = lib.mkDefault [
+      "dtbs/qcom/sm8250-${config.mobile.device.name}.dtb"
+    ];
+  };
+
+  mobile.usb.mode = "gadgetfs";
+  mobile.usb.idVendor = lib.mkDefault "18D1"; # Google
+  mobile.usb.idProduct = lib.mkDefault "D001"; # "Nexus 4"
+
+  mobile.usb.gadgetfs.functions = {
+    adb = "ffs.adb";
+    mass_storage = "mass_storage.0";
+    rndis = "rndis.usb0";
+  };
+}

--- a/modules/hardware-qualcomm.nix
+++ b/modules/hardware-qualcomm.nix
@@ -19,6 +19,7 @@ let
     cfg.qualcomm-sdm660.enable
     cfg.qualcomm-sdm845.enable
     cfg.qualcomm-sm6125.enable
+    cfg.qualcomm-sm8250.enable
     cfg.qualcomm-apq8064-1aa.enable
   ];
 in
@@ -74,6 +75,11 @@ in
       default = false;
       description = "enable when SOC is SM6125";
     };
+    hardware.socs.qualcomm-sm8250.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "enable when SOC is SM8250";
+    };
   };
 
   config = mkMerge [
@@ -121,6 +127,12 @@ in
     {
       mobile = mkIf cfg.qualcomm-sm6125.enable {
         system.system = "aarch64-linux";
+      };
+    }
+    {
+      mobile = mkIf cfg.qualcomm-sm8250.enable {
+        system.system = "aarch64-linux";
+        boot.boot-control.enable = mkDefault true;
       };
     }
     {


### PR DESCRIPTION
Add the Qualcomm SM8250 SoC to `hardware-qualcomm.nix` and introduce a generic `sm8250-mainline` device family.

The family provides common configuration shared across SM8250 devices:
- SoC registration and boot control
- Adreno a650 video firmware for initrd
- Device firmware inclusion when enabled
- Standard Android boot image offsets
- Appended DTB convention (`sm8250-<device_name>.dtb`)
- GadgetFS USB mode

Individual devices import this family and supply their own kernel package and device-specific configuration.