### PR TITLE
treewide: Adapt to changes in Nixpkgs

### DIFF
--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -221,6 +221,8 @@ in
 
       mobile.documentation.systemTypeFargment = ./. + "/device-notes.${flashingMethod}.adoc.erb";
 
+      hardware.deviceTree.enable = false;
+
       assertions = [
         {
           assertion = config.mobile.system.android.appendDTB == null || config.mobile.system.android.bootimg.dt == null;

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -160,6 +160,8 @@ in
           disk-image = config.mobile.generatedDiskImages.disk-image.output;
         };
       };
+
+      hardware.deviceTree.enable = false;
     })
   ];
 }

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -189,6 +189,8 @@ in
           disk-image = config.mobile.generatedDiskImages.disk-image.output;
         };
       };
+
+      hardware.deviceTree.enable = false;
     })
   ];
 }

--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -160,9 +160,19 @@ in
 
 # Used to provide the default kernelFile
 , kernelFileExtension ? if isCompressed != false then ".${isCompressed}" else ""
-, kernelTarget ? if platform.linux-kernel.target == "Image"
-    then "${platform.linux-kernel.target}${kernelFileExtension}"
-    else platform.linux-kernel.target
+, kernelTarget ?
+    if stdenv.hostPlatform.isx86 then
+      "bzImage"
+    else if stdenv.hostPlatform.isAarch32 then
+      "zImage"
+    else if stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV then
+      "Image"
+    else if stdenv.hostPlatform.isLoongArch64 then
+      "vmlinuz.efi"
+    else
+      "vmlinux"
+, buildDTBs ?
+    stdenv.hostPlatform.isAarch || stdenv.hostPlatform.isRiscV || stdenv.hostPlatform.isLoongArch64
 
 , ...
 } @ inputArgs:
@@ -194,8 +204,6 @@ let
   pkg-config-helper = writeShellScriptBin "pkg-config" ''
     exec ${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config "$@"
   '';
-
-  hasDTB = platform.linux-kernel ? DTB && platform.linux-kernel.DTB;
 in
 
 # This `let` block allows us to have a self-reference to this derivation.
@@ -217,7 +225,7 @@ stdenv.mkDerivation (inputArgs // {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl bc net-tools openssl rsync gmp libmpc mpfr ]
-    ++ optional (platform.linux-kernel.target == "uImage") buildPackages.ubootTools
+    ++ optional (kernelTarget == "uImage") buildPackages.ubootTools
     ++ optional (lib.versionAtLeast version "4.14" && lib.versionOlder version "5.8") libelf
     ++ optional (lib.versionAtLeast version "4.15") util-linux
     ++ optionals (lib.versionAtLeast version "4.16") [ bison flex ]
@@ -488,7 +496,7 @@ stdenv.mkDerivation (inputArgs // {
     rm -vf "$out/lib/modules/${modDirVersion}/build"
     rm -vf "$out/lib/modules/${modDirVersion}/source"
 
-  '' + optionalString hasDTB ''
+  '' + optionalString buildDTBs ''
     echo ":: Installing DTBs"
     mkdir -p $out/dtbs/
     make $makeFlags "''${makeFlagsArray[@]}" dtbs dtbs_install INSTALL_DTBS_PATH=$out/dtbs


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/530133 (31d1d80b3fb5ca92da5836376cae81fa523da428) made this change necessary.

Fixes https://github.com/mobile-nixos/mobile-nixos/issues/880.

I haven't tested this change yet besides making sure that my personal Mobile NixOS configuration still builds.