### PR TITLE
CONTRIBUTING: Add note about “AI”[sic] (*sigh*) contributions

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -6,6 +6,33 @@ As Mobile NixOS is a superset on top of NixOS, you should read the link:https://
 contributing guidelines] of the NixOS project. Many of the points apply just
 the same with Mobile NixOS.
 
+== “AI”-assisted contributions
+
+[NOTE]
+====
+Using pre-existing *boilerplate*, *snippets*, or *syntax suggestions* from your IDE are not considered as “AI”-assisted changes.
+====
+
+Contributions written largely with help of LLMs (_Large Language Models_), other “AI” (or non-“AI”), or similar systems are not welcome.
+Such systems of concern are generally using statistical models built on “knowledge” acquired for the purpose without express consent, and with disregard of the authorship and attribution.
+
+This includes, but is not limited to:
+
+ - Using them to generate comments
+ - Using them to generate documentation
+ - Using them to generate code
+
+Contributions should be largely authored by the people in the commit information, e.g. the `Committer,` `Author`, `Signed-off-by`, and `Co-authored-by` fields, exclusively.
+
+If you are unsure, or you had help from automated “AI”-generation in _part_ of your contribution, please tell us when contributing.
+It does not mean the contribution will be rejected outright.
+We will evaluate on a case-by-case basis.
+We value honesty, and take it into consideration.
+
+The same applies to interactions with the repository and community.
+Using the output of “AI” as part of your interactions such as issues, pull requests or comments is not welcome.
+
+An exception is made for machine translation of prose, as long as it is clearly outlined that machine translation is used.
 
 == Opening issues
 


### PR DESCRIPTION
I'd like to see the top *n* contributors who had more than one commit to the repository in the past 12 months to please ack, or nack, this policy.

 - ~~@samueldr~~ (✔️)
 - @Luflosi
 - @benaryorg

I've used the [contributors page](https://github.com/mobile-nixos/mobile-nixos/graphs/contributors?from=05%2F07%2F2025) to determine this.

The wording is [the wording I used in the Jovian NixOS project](https://github.com/Jovian-Experiments/Jovian-NixOS/commit/a94221d011aa4251430fa9c881222d5c792af05f), with an added clause for interactions other than generated code, and an explicit carve-out to prevent “rules-lawyering“ around machine translation.

I don't expect the wording to be controversial, but unless there is a real blocker, I don't think there's any need for bikeshedding here.