### PR TITLE
migrate stdenv.is{Linux,Aarch*} to stdenv.hostPlatform

### DIFF
--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -193,7 +193,7 @@ let
 
     # Necessary so it uses `gcc` instead of `ld` for linking.
     # https://github.com/mruby/mruby/blob/35be8b252495d92ca811d76996f03c470ee33380/tasks/toolchains/gcc.rake#L25
-    preBuild = if stdenv.isLinux then "unset LD" else null;
+    preBuild = if stdenv.hostPlatform.isLinux then "unset LD" else null;
 
     SKIP_HOST = if isCross then "true" else null;
 

--- a/support/kernel-config/configuration.nix
+++ b/support/kernel-config/configuration.nix
@@ -49,11 +49,12 @@ let
   ];
   inherit (pkgs.stdenv)
     is64bit
+    isAarch32
     isAarch64
     isx86_32
     isx86_64
   ;
-  isArm = pkgs.stdenv.isAarch64 || pkgs.stdenv.isAarch32;
+  isArm =  isAarch32 || isAarch64;
   isx86 = isx86_32 || isx86_64;
 
   evaluatedStructuredConfig = import ../../overlay/mobile-nixos/kernel/eval-config.nix  rec {

--- a/support/kernel-config/configuration.nix
+++ b/support/kernel-config/configuration.nix
@@ -47,7 +47,7 @@ let
     "ARCH_XGENE"
     "ARCH_ZYNQMP"
   ];
-  inherit (pkgs.stdenv)
+  inherit (pkgs.stdenv.hostPlatform)
     is64bit
     isAarch32
     isAarch64


### PR DESCRIPTION
The *nixos-unstable* branch has gated `stdenv.isLinux` behind *allowAliases* in preparation for removal.
This breaks evals with *allowAliases* set to false (my case), and throws a warning for evals with *allowAliases* set to true.
Usage should migrate to using the `stdenv.hostPlatform.isLinux` counterparts either way.
As far as I can tell all the attributes used by this PR are already available on *nixos-26.05* at time of writing, so this should not cause any compatibility issues.

Fixes #885